### PR TITLE
Issue #12 - hot fixes for Polygon.IO REST API

### DIFF
--- a/Alpaca.Markets.Tests/RestClientExtendedTest.cs
+++ b/Alpaca.Markets.Tests/RestClientExtendedTest.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Xunit;
+
+namespace Alpaca.Markets.Tests
+{
+    public sealed class RestClientExtendedTest
+    {
+        private readonly RestClient _restClient = ClientsFactory.GetRestClient();
+
+        [Fact]
+        public async void ListHistoricalQuotesReturnsEmptyListForSunday()
+        {
+            var historicalItems = await _restClient
+                .ListHistoricalQuotesAsync("AAPL", new DateTime(2018, 8, 5));
+
+            Assert.NotNull(historicalItems);
+
+            Assert.NotNull(historicalItems.Items);
+            Assert.Empty(historicalItems.Items);
+        }
+    }
+}

--- a/Alpaca.Markets.Tests/RestClientExtendedTest.cs
+++ b/Alpaca.Markets.Tests/RestClientExtendedTest.cs
@@ -18,5 +18,35 @@ namespace Alpaca.Markets.Tests
             Assert.NotNull(historicalItems.Items);
             Assert.Empty(historicalItems.Items);
         }
+
+        [Fact]
+        public async void ListDayAggregatesForSpecificDatesWorks()
+        {
+            var dateInto = DateTime.Today;
+            var dateFrom = dateInto.AddDays(-7);
+
+            var historicalItems = await _restClient
+                .ListDayAggregatesAsync("AAPL", dateFrom, dateInto);
+
+            Assert.NotNull(historicalItems);
+
+            Assert.NotNull(historicalItems.Items);
+            Assert.NotEmpty(historicalItems.Items);
+        }
+
+        [Fact]
+        public async void ListMinuteAggregatesForSpecificDatesWorks()
+        {
+            var dateInto = DateTime.Today;
+            var dateFrom = dateInto.AddDays(-7);
+
+            var historicalItems = await _restClient
+                .ListMinuteAggregatesAsync("AAPL", dateFrom, dateInto, 100);
+
+            Assert.NotNull(historicalItems);
+
+            Assert.NotNull(historicalItems.Items);
+            Assert.NotEmpty(historicalItems.Items);
+        }
     }
 }

--- a/Alpaca.Markets/Messages/JsonHistoricalItems.cs
+++ b/Alpaca.Markets/Messages/JsonHistoricalItems.cs
@@ -6,17 +6,19 @@ namespace Alpaca.Markets
 {
     internal abstract class JsonHistoricalItems<TApi, TJson> where TJson : TApi
     {
+        private static readonly IReadOnlyCollection<TApi> _empty = new TApi[0];
+
         [JsonProperty(PropertyName = "status", Required = Required.Default)]
         public String Status { get; set; }
 
         [JsonProperty(PropertyName = "symbol", Required = Required.Always)]
         public String Symbol { get; set; }
 
-        [JsonProperty(PropertyName = "ticks", Required = Required.Always)]
+        [JsonProperty(PropertyName = "ticks", Required = Required.Default)]
         public List<TJson> ItemsList { get; set; }
 
         [JsonIgnore]
         public IReadOnlyCollection<TApi> Items =>
-            (IReadOnlyCollection<TApi>)ItemsList;
+            (IReadOnlyCollection<TApi>)ItemsList ?? _empty;
     }
 }

--- a/Alpaca.Markets/RestClient.Polygon.cs
+++ b/Alpaca.Markets/RestClient.Polygon.cs
@@ -119,8 +119,8 @@ namespace Alpaca.Markets
             {
                 Path = $"v1/historic/agg/day/{symbol}",
                 Query = getDefaultPolygonApiQueryBuilder()
-                    .AddParameter("from", dateFromInclusive, "dd-MM-yyyy")
-                    .AddParameter("to", dateIntoInclusive, "dd-MM-yyyy")
+                    .AddParameter("from", dateFromInclusive, "yyyy-MM-dd")
+                    .AddParameter("to", dateIntoInclusive, "yyyy-MM-dd")
                     .AddParameter("limit", limit)
             };
 
@@ -148,8 +148,8 @@ namespace Alpaca.Markets
             {
                 Path = $"v1/historic/agg/minute/{symbol}",
                 Query = getDefaultPolygonApiQueryBuilder()
-                    .AddParameter("from", dateFromInclusive, "dd-MM-yyyy")
-                    .AddParameter("to", dateIntoInclusive, "dd-MM-yyyy")
+                    .AddParameter("from", dateFromInclusive, "yyyy-MM-dd")
+                    .AddParameter("to", dateIntoInclusive, "yyyy-MM-dd")
                     .AddParameter("limit", limit)
             };
 


### PR DESCRIPTION
- If returned JSON contains 'null' value in 'ticks' field we have to handle it w/o exception and return empty list.
- If dates are specified for these requests they should be encoded in 'yyyy-MM-dd' form.