### PR TITLE
Issue #14 - Alpaca streaming client issues

### DIFF
--- a/Alpaca.Markets.Tests/OrderActionsTest.cs
+++ b/Alpaca.Markets.Tests/OrderActionsTest.cs
@@ -13,6 +13,11 @@ namespace Alpaca.Markets.Tests
         {
             using (var sockClient = ClientsFactory.GetSockClient())
             {
+                sockClient.OnError += (ex) =>
+                {
+                    Assert.Null(ex.Message);
+                };
+
                 await sockClient.ConnectAsync();
 
                 var waitObject = new AutoResetEvent(false);
@@ -47,9 +52,8 @@ namespace Alpaca.Markets.Tests
 
                 Assert.True(result);
 
-                // TODO: olegra - why cancellation not reported here?
-                //Assert.True(waitObject.WaitOne(
-                //    TimeSpan.FromSeconds(10)));
+                Assert.True(waitObject.WaitOne(
+                    TimeSpan.FromSeconds(10)));
 
                 await sockClient.DisconnectAsync();
             }

--- a/Alpaca.Markets.Tests/SockClientTest.cs
+++ b/Alpaca.Markets.Tests/SockClientTest.cs
@@ -11,6 +11,11 @@ namespace Alpaca.Markets.Tests
         {
             using (var client = ClientsFactory.GetSockClient())
             {
+                client.OnError += (ex) =>
+                {
+                    Assert.Null(ex.Message);
+                };
+
                 await client.ConnectAsync();
 
                 var waitObject = new AutoResetEvent(false);

--- a/Alpaca.Markets/Messages/JsonTradeUpdate.cs
+++ b/Alpaca.Markets/Messages/JsonTradeUpdate.cs
@@ -15,7 +15,7 @@ namespace Alpaca.Markets
         [JsonProperty(PropertyName = "qty", Required = Required.Default)]
         public Int64? Quantity { get; set; }
 
-        [JsonProperty(PropertyName = "timestamp", Required = Required.Always)]
+        [JsonProperty(PropertyName = "timestamp", Required = Required.Default)]
         public DateTime Timestamp { get; set; }
 
         [JsonProperty(PropertyName = "order", Required = Required.Always)]

--- a/Alpaca.Markets/RestClient.cs
+++ b/Alpaca.Markets/RestClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
@@ -69,6 +70,11 @@ namespace Alpaca.Markets
                 .Add(new MediaTypeWithQualityHeaderValue("application/json"));
             _polygonHttpClient.BaseAddress =
                 polygonRestApi ?? new Uri("https://api.polygon.io");
+
+#if NET45
+            ServicePointManager.SecurityProtocol =
+                SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11;
+#endif
         }
 
         private async Task<TApi> getSingleObjectAsync<TApi, TJson>(

--- a/Alpaca.Markets/SockClient.cs
+++ b/Alpaca.Markets/SockClient.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using WebSocket4Net;
+using System.Security.Authentication;
 
 namespace Alpaca.Markets
 {
@@ -59,7 +60,8 @@ namespace Alpaca.Markets
             };
             uriBuilder.Path += "/stream";
 
-            _webSocket = new WebSocket(uriBuilder.Uri.ToString());
+            _webSocket = new WebSocket(uriBuilder.Uri.ToString(),
+                sslProtocols: SslProtocols.Tls11 | SslProtocols.Tls12);
 
             _webSocket.Opened += handleOpened;
             _webSocket.Closed += handleClosed;
@@ -172,6 +174,11 @@ namespace Alpaca.Markets
                 case "account_updates":
                     handleAccountUpdates(
                         data.ToObject<JsonAccountUpdate>());
+                    break;
+
+                default:
+                    OnError?.Invoke(new InvalidOperationException(
+                        $"Unexpected message type '{stream}' received."));
                     break;
             }
         }


### PR DESCRIPTION
Several issues are solved in this commit:

* TLS 1.1 and TLS 1.2 forced for .NET Framework version of code for both REST and WebSocket APIs.
* Error handling code updated and unit tests updated for Alpaca streaming checks.