### PR TITLE
Alpaca REST API throttling implemented

### DIFF
--- a/Alpaca.Markets.Tests/RestClientExtendedTest.cs
+++ b/Alpaca.Markets.Tests/RestClientExtendedTest.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Alpaca.Markets.Tests
@@ -47,6 +50,19 @@ namespace Alpaca.Markets.Tests
 
             Assert.NotNull(historicalItems.Items);
             Assert.NotEmpty(historicalItems.Items);
+        }
+
+        [Fact]
+        public void AlpacaRestApiThrottlingWorks()
+        {
+            var tasks = new Task[300];
+            for (var i = 0; i < tasks.Length; ++i)
+            {
+                tasks[i] = _restClient.GetClockAsync();
+            }
+
+            Task.WaitAll(tasks);
+            Assert.DoesNotContain(tasks, task => task.IsFaulted);
         }
     }
 }

--- a/Alpaca.Markets/FakeThrottler.cs
+++ b/Alpaca.Markets/FakeThrottler.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Alpaca.Markets
+{
+    internal sealed class FakeThrottler : IThrottler
+    {
+        private FakeThrottler() { }
+
+        public static IThrottler Instance { get; } = new FakeThrottler();
+
+        public Int32 MaxAttempts => 1;
+
+        public void WaitToProceed() { }
+    }
+}

--- a/Alpaca.Markets/IThrottler.cs
+++ b/Alpaca.Markets/IThrottler.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Alpaca.Markets
+{
+    internal interface IThrottler
+    {
+        /// <summary>
+        /// Gets flag indicating we are currently being rate limited.
+        /// </summary>
+        Int32 MaxAttempts { get; }
+
+        /// <summary>
+        /// Blocks the current thread indefinitely until allowed to proceed.
+        /// </summary>
+        void WaitToProceed();
+    }
+}

--- a/Alpaca.Markets/RateThrottler.cs
+++ b/Alpaca.Markets/RateThrottler.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace Alpaca.Markets
+{
+    internal sealed class RateThrottler : IThrottler, IDisposable
+    {
+        public Int32 MaxAttempts { get; }
+
+        /// <summary>
+        /// Times (in millisecond ticks) at which the semaphore should be exited.
+        /// </summary>
+        private readonly ConcurrentQueue<Int32> _exitTimes;
+
+        /// <summary>
+        /// Semaphore used to count and limit the number of occurrences per unit time.
+        /// </summary>
+        private readonly SemaphoreSlim _semaphore;
+
+        /// <summary>
+        /// Timer used to trigger exiting the semaphore.
+        /// </summary>
+        private readonly Timer _exitTimer;
+
+        /// <summary>
+        /// The length of the time unit, in milliseconds.
+        /// </summary>
+        private readonly Int32 _timeUnitMilliseconds;
+
+        /// <summary>
+        /// Initializes a <see cref="RateThrottler" /> with a rate of <paramref name="occurrences" />
+        /// per <paramref name="timeUnit" />.
+        /// </summary>
+        /// <param name="occurrences">Number of occurrences allowed per unit of time.</param>
+        /// <param name="maxAttempts">Number of maximal retry attampts in case of any HTTP error.</param>
+        /// <param name="timeUnit">Length of the time unit.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// If <paramref name="occurrences" />, <paramref name="maxAttempts"/> or <paramref name="timeUnit" /> is negative.
+        /// </exception>
+        public RateThrottler(
+            Int32 occurrences,
+            Int32 maxAttempts,
+            TimeSpan timeUnit)
+        {
+            if (occurrences <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(occurrences),
+                    "Number of occurrences must be a positive integer");
+            }
+            if (maxAttempts <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxAttempts),
+                    "Number of maximal retry attempts must be a positive integer");
+            }
+            if (timeUnit != timeUnit.Duration())
+            {
+                throw new ArgumentOutOfRangeException(nameof(timeUnit), "Time unit must be a positive span of time");
+            }
+            if (timeUnit >= TimeSpan.FromMilliseconds(UInt32.MaxValue))
+            {
+                throw new ArgumentOutOfRangeException(nameof(timeUnit), "Time unit must be less than 2^32 milliseconds");
+            }
+
+            _timeUnitMilliseconds = (Int32) timeUnit.TotalMilliseconds;
+            MaxAttempts = maxAttempts;
+
+            // Create the semaphore, with the number of occurrences as the maximum count.
+            _semaphore = new SemaphoreSlim(occurrences, occurrences);
+
+            // Create a queue to hold the semaphore exit times.
+            _exitTimes = new ConcurrentQueue<Int32>();
+
+            // Create a timer to exit the semaphore. Use the time unit as the original
+            // interval length because that's the earliest we will need to exit the semaphore.
+            _exitTimer = new Timer(exitTimerCallback, null, _timeUnitMilliseconds, -1);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            _semaphore.Dispose();
+            _exitTimer.Dispose();
+        }
+
+        /// <inheritdoc />
+        public void WaitToProceed()
+        {
+
+            // Block until we can enter the semaphore or until the timeout expires.
+            var entered = _semaphore.Wait(Timeout.Infinite);
+
+            // If we entered the semaphore, compute the corresponding exit time 
+            // and add it to the queue.
+            if (entered)
+            {
+                var timeToExit = unchecked(Environment.TickCount + _timeUnitMilliseconds);
+                _exitTimes.Enqueue(timeToExit);
+            }
+        }
+
+        // Callback for the exit timer that exits the semaphore based on exit times 
+        // in the queue and then sets the timer for the nextexit time.
+        private void exitTimerCallback(Object state)
+        {
+            // While there are exit times that are passed due still in the queue,
+            // exit the semaphore and dequeue the exit time.
+            Int32 exitTime;
+            while (_exitTimes.TryPeek(out exitTime)
+                   && unchecked(exitTime - Environment.TickCount) <= 0)
+            {
+                _semaphore.Release();
+                _exitTimes.TryDequeue(out exitTime);
+            }
+
+            // Try to get the next exit time from the queue and compute
+            // the time until the next check should take place. If the 
+            // queue is empty, then no exit times will occur until at least
+            // one time unit has passed.
+            Int32 timeUntilNextCheck;
+            if (_exitTimes.TryPeek(out exitTime))
+            {
+                timeUntilNextCheck = unchecked(exitTime - Environment.TickCount);
+            }
+            else
+            {
+                timeUntilNextCheck = _timeUnitMilliseconds;
+            }
+
+            // Set the timer.
+            _exitTimer.Change(timeUntilNextCheck, -1);
+        }
+    }
+}

--- a/Alpaca.Markets/RestClient.General.cs
+++ b/Alpaca.Markets/RestClient.General.cs
@@ -15,7 +15,8 @@ namespace Alpaca.Markets
         /// <returns>Read-only account information.</returns>
         public Task<IAccount> GetAccountAsync()
         {
-            return getSingleObjectAsync<IAccount, JsonAccount>(_alpacaHttpClient, "v1/account");
+            return getSingleObjectAsync<IAccount, JsonAccount>(
+                _alpacaHttpClient, _alpacaRestApiThrottler, "v1/account");
         }
 
         /// <summary>
@@ -36,7 +37,8 @@ namespace Alpaca.Markets
                     .AddParameter("asset_class", assetClass)
             };
 
-            return getObjectsListAsync<IAsset, JsonAsset>(_alpacaHttpClient, builder);
+            return getObjectsListAsync<IAsset, JsonAsset>(
+                _alpacaHttpClient, _alpacaRestApiThrottler, builder);
         }
 
         /// <summary>
@@ -47,7 +49,8 @@ namespace Alpaca.Markets
         public Task<IAsset> GetAssetAsync(
             String symbol)
         {
-            return getSingleObjectAsync<IAsset, JsonAsset>(_alpacaHttpClient, $"v1/assets/{symbol}");
+            return getSingleObjectAsync<IAsset, JsonAsset>(
+                _alpacaHttpClient, _alpacaRestApiThrottler, $"v1/assets/{symbol}");
         }
 
         /// <summary>
@@ -71,7 +74,8 @@ namespace Alpaca.Markets
                     .AddParameter("limit", limitOrderNumber)
             };
 
-            return getObjectsListAsync<IOrder, JsonOrder>(_alpacaHttpClient, builder);
+            return getObjectsListAsync<IOrder, JsonOrder>(
+                _alpacaHttpClient, _alpacaRestApiThrottler, builder);
         }
 
         /// <summary>
@@ -114,6 +118,8 @@ namespace Alpaca.Markets
                 ClientOrderId = clientOrderId
             };
 
+            _alpacaRestApiThrottler.WaitToProceed();
+
             var serializer = new JsonSerializer();
             using (var stringWriter = new StringWriter())
             {
@@ -151,7 +157,8 @@ namespace Alpaca.Markets
                     .AddParameter("client_order_id", clientOrderId)
             };
 
-            return getSingleObjectAsync<IOrder, JsonOrder>(_alpacaHttpClient, builder);
+            return getSingleObjectAsync<IOrder, JsonOrder>(
+                _alpacaHttpClient, _alpacaRestApiThrottler, builder);
         }
 
         /// <summary>
@@ -162,7 +169,8 @@ namespace Alpaca.Markets
         public Task<IOrder> GetOrderAsync(
             Guid orderId)
         {
-            return getSingleObjectAsync<IOrder, JsonOrder>(_alpacaHttpClient, $"v1/orders/{orderId:D}");
+            return getSingleObjectAsync<IOrder, JsonOrder>(
+                _alpacaHttpClient, _alpacaRestApiThrottler, $"v1/orders/{orderId:D}");
         }
 
         /// <summary>
@@ -173,6 +181,8 @@ namespace Alpaca.Markets
         public async Task<Boolean> DeleteOrderAsync(
             Guid orderId)
         {
+            _alpacaRestApiThrottler.WaitToProceed();
+
             using (var response = await _alpacaHttpClient.DeleteAsync($"v1/orders/{orderId:D}"))
             {
                 return response.IsSuccessStatusCode;
@@ -185,7 +195,8 @@ namespace Alpaca.Markets
         /// <returns>Read-only list of position information objects.</returns>
         public Task<IEnumerable<IPosition>> ListPositionsAsync()
         {
-            return getObjectsListAsync<IPosition, JsonPosition>(_alpacaHttpClient, "v1/positions");
+            return getObjectsListAsync<IPosition, JsonPosition>(
+                _alpacaHttpClient, _alpacaRestApiThrottler, "v1/positions");
         }
 
         /// <summary>
@@ -196,7 +207,8 @@ namespace Alpaca.Markets
         public Task<IPosition> GetPositionAsync(
             String symbol)
         {
-            return getSingleObjectAsync<IPosition, JsonPosition>(_alpacaHttpClient, $"v1/positions/{symbol}");
+            return getSingleObjectAsync<IPosition, JsonPosition>(
+                _alpacaHttpClient, _alpacaRestApiThrottler, $"v1/positions/{symbol}");
         }
 
         /// <summary>
@@ -205,7 +217,8 @@ namespace Alpaca.Markets
         /// <returns>Read-only clock information object.</returns>
         public Task<IClock> GetClockAsync()
         {
-            return getSingleObjectAsync<IClock, JsonClock>(_alpacaHttpClient, "v1/clock");
+            return getSingleObjectAsync<IClock, JsonClock>(
+                _alpacaHttpClient, _alpacaRestApiThrottler, "v1/clock");
         }
 
         /// <summary>
@@ -226,7 +239,8 @@ namespace Alpaca.Markets
                     .AddParameter("end", endDateInclusive, "yyyy-MM-dd")
             };
 
-            return getObjectsListAsync<ICalendar, JsonCalendar>(_alpacaHttpClient, builder);
+            return getObjectsListAsync<ICalendar, JsonCalendar>(
+                _alpacaHttpClient, _alpacaRestApiThrottler, builder);
         }
     }
 }

--- a/Alpaca.Markets/RestClient.Market.cs
+++ b/Alpaca.Markets/RestClient.Market.cs
@@ -30,7 +30,8 @@ namespace Alpaca.Markets
                     .AddParameter("end_dt", endTimeInclusive)
             };
 
-            return getObjectsListAsync<IAssetBars, JsonAssetBars>(_alpacaHttpClient, builder);
+            return getObjectsListAsync<IAssetBars, JsonAssetBars>(
+                _alpacaHttpClient, _alpacaRestApiThrottler, builder);
         }
 
         /// <summary>
@@ -56,7 +57,8 @@ namespace Alpaca.Markets
                     .AddParameter("end_dt", endTimeInclusive)
             };
 
-            return getSingleObjectAsync<IAssetBars, JsonAssetBars>(_alpacaHttpClient, builder);
+            return getSingleObjectAsync<IAssetBars, JsonAssetBars>(
+                _alpacaHttpClient, _alpacaRestApiThrottler, builder);
         }
 
         /// <summary>
@@ -74,7 +76,8 @@ namespace Alpaca.Markets
                     .AddParameter("symbols", String.Join(",", symbols))
             };
 
-            return getObjectsListAsync<IQuote, JsonQuote>(_alpacaHttpClient, builder);
+            return getObjectsListAsync<IQuote, JsonQuote>(
+                _alpacaHttpClient, _alpacaRestApiThrottler, builder);
         }
 
         /// <summary>
@@ -86,7 +89,7 @@ namespace Alpaca.Markets
             String symbol)
         {
             return getSingleObjectAsync<IQuote, JsonQuote>(
-                _alpacaHttpClient, $"v1/assets/{symbol}/quote");
+                _alpacaHttpClient, _alpacaRestApiThrottler, $"v1/assets/{symbol}/quote");
         }
 
         /// <summary>
@@ -104,7 +107,8 @@ namespace Alpaca.Markets
                     .AddParameter("symbols", String.Join(",", symbols))
             };
 
-            return getObjectsListAsync<IFundamental, JsonFundamental>(_alpacaHttpClient, builder);
+            return getObjectsListAsync<IFundamental, JsonFundamental>(
+                _alpacaHttpClient, _alpacaRestApiThrottler, builder);
         }
 
         /// <summary>
@@ -116,7 +120,7 @@ namespace Alpaca.Markets
             String symbol)
         {
             return getSingleObjectAsync<IFundamental, JsonFundamental>(
-                _alpacaHttpClient, $"v1/assets/{symbol}/fundamental");
+                _alpacaHttpClient, _alpacaRestApiThrottler, $"v1/assets/{symbol}/fundamental");
         }
     }
 }

--- a/Alpaca.Markets/RestClient.Polygon.cs
+++ b/Alpaca.Markets/RestClient.Polygon.cs
@@ -20,7 +20,8 @@ namespace Alpaca.Markets
                 Query = getDefaultPolygonApiQueryBuilder()
             };
 
-            return getObjectsListAsync<IExchange, JsonExchange>(_polygonHttpClient, builder);
+            return getObjectsListAsync<IExchange, JsonExchange>(
+                _polygonHttpClient, FakeThrottler.Instance, builder);
         }
 
         /// <summary>
@@ -40,7 +41,7 @@ namespace Alpaca.Markets
 
             return getSingleObjectAsync
                 <IReadOnlyDictionary<String,String>, Dictionary<String, String>>(
-                    _polygonHttpClient, builder);
+                    _polygonHttpClient, FakeThrottler.Instance, builder);
         }
 
         /// <summary>
@@ -69,7 +70,7 @@ namespace Alpaca.Markets
             return getSingleObjectAsync
                 <IDayHistoricalItems<IHistoricalTrade>,
                     JsonDayHistoricalItems<IHistoricalTrade, JsonHistoricalTrade>>(
-                _polygonHttpClient, builder);
+                _polygonHttpClient, FakeThrottler.Instance, builder);
         }
 
         /// <summary>
@@ -98,7 +99,7 @@ namespace Alpaca.Markets
             return getSingleObjectAsync
                 <IDayHistoricalItems<IHistoricalQuote>,
                     JsonDayHistoricalItems<IHistoricalQuote, JsonHistoricalQuote>>(
-                _polygonHttpClient, builder);
+                _polygonHttpClient, FakeThrottler.Instance, builder);
         }
 
         /// <summary>
@@ -127,7 +128,7 @@ namespace Alpaca.Markets
             return getSingleObjectAsync
                 <IAggHistoricalItems<IBar>,
                     JsonAggHistoricalItems<IBar, JsonDayBar>>(
-                _polygonHttpClient, builder);
+                _polygonHttpClient, FakeThrottler.Instance, builder);
         }
 
         /// <summary>
@@ -156,7 +157,7 @@ namespace Alpaca.Markets
             return getSingleObjectAsync
             <IAggHistoricalItems<IBar>,
                 JsonAggHistoricalItems<IBar, JsonMinuteBar>>(
-                _polygonHttpClient, builder);
+                _polygonHttpClient, FakeThrottler.Instance, builder);
         }
 
         /// <summary>
@@ -174,7 +175,7 @@ namespace Alpaca.Markets
             };
 
             return getSingleObjectAsync<ILastTrade, JsonLastTrade>(
-                _polygonHttpClient, builder);
+                _polygonHttpClient, FakeThrottler.Instance, builder);
         }
 
         /// <summary>
@@ -192,7 +193,7 @@ namespace Alpaca.Markets
             };
 
             return getSingleObjectAsync<ILastQuote, JsonLastQuote>(
-                _polygonHttpClient, builder);
+                _polygonHttpClient, FakeThrottler.Instance, builder);
         }
 
         /// <summary>
@@ -214,7 +215,7 @@ namespace Alpaca.Markets
 
             var dictionary = await getSingleObjectAsync
                 <IDictionary<String, String>, Dictionary<String, String>>(
-                    _polygonHttpClient, builder);
+                    _polygonHttpClient, FakeThrottler.Instance, builder);
 
             return dictionary
                 .ToDictionary(


### PR DESCRIPTION
Up to 200 calls per minute with 5 retry attempts for all GET methods.