### PR TITLE
Removed Exchange from IStreamAgg/JsonStreamAgg

### DIFF
--- a/Alpaca.Markets/Interfaces/IStreamAgg.cs
+++ b/Alpaca.Markets/Interfaces/IStreamAgg.cs
@@ -10,12 +10,7 @@ namespace Alpaca.Markets
         /// <summary>
         /// Gets asset name.
         /// </summary>
-        String Symbol { get; }
-
-        /// <summary>
-        /// Gets asset's exchange identifier.
-        /// </summary>
-        Int64 Exchange { get; }
+        String Symbol { get; } 
 
         /// <summary>
         /// Gets bar average price.

--- a/Alpaca.Markets/Interfaces/IStreamAgg.cs
+++ b/Alpaca.Markets/Interfaces/IStreamAgg.cs
@@ -13,6 +13,12 @@ namespace Alpaca.Markets
         String Symbol { get; } 
 
         /// <summary>
+        /// Gets asset's exchange identifier.
+        /// </summary>
+        [Obsolete("Exchange is deprecated and will be removed in a future version of the SDK.")]
+        Int64 Exchange { get; }
+        
+        /// <summary>
         /// Gets bar average price.
         /// </summary>
         Decimal Average { get; }

--- a/Alpaca.Markets/Interfaces/IStreamAgg.cs
+++ b/Alpaca.Markets/Interfaces/IStreamAgg.cs
@@ -15,7 +15,7 @@ namespace Alpaca.Markets
         /// <summary>
         /// Gets asset's exchange identifier.
         /// </summary>
-        [Obsolete("Exchange is deprecated and will be removed in a future version of the SDK.")]
+        [Obsolete("This property will be removed in upcoming major SDK release.")]
         Int64 Exchange { get; }
         
         /// <summary>

--- a/Alpaca.Markets/Messages/JsonStreamAgg.cs
+++ b/Alpaca.Markets/Messages/JsonStreamAgg.cs
@@ -9,9 +9,6 @@ namespace Alpaca.Markets
         [JsonProperty(PropertyName = "sym", Required = Required.Always)]
         public String Symbol { get; set; }
 
-        [JsonProperty(PropertyName = "x", Required = Required.Always)]
-        public Int64 Exchange { get; set; }
-
         [JsonProperty(PropertyName = "o", Required = Required.Always)]
         public Decimal Open { get; set; }
 

--- a/Alpaca.Markets/Messages/JsonStreamAgg.cs
+++ b/Alpaca.Markets/Messages/JsonStreamAgg.cs
@@ -9,6 +9,9 @@ namespace Alpaca.Markets
         [JsonProperty(PropertyName = "sym", Required = Required.Always)]
         public String Symbol { get; set; }
 
+        [JsonProperty(PropertyName = "x", Required = Required.Default)]
+        public Int64 Exchange { get; set; }
+
         [JsonProperty(PropertyName = "o", Required = Required.Always)]
         public Decimal Open { get; set; }
 


### PR DESCRIPTION
NatsClient was failing while attempting to deserialize a required `Exchange` property. I spoke with Quinton at Polygon.io and he said this property should be removed from the model as the data comes from a consolidated feed of many exchanges.