### PR TITLE
Issue #73 fixed - proper data formatting for all REST calls

### DIFF
--- a/Alpaca.Markets.Tests/RestClientExtendedTest.cs
+++ b/Alpaca.Markets.Tests/RestClientExtendedTest.cs
@@ -64,6 +64,16 @@ namespace Alpaca.Markets.Tests
             Task.WaitAll(tasks);
             Assert.DoesNotContain(tasks, task => task.IsFaulted);
         }
+        
+        [Fact]
+        public async void ListOrdersForDatesWorks()
+        {
+            var orders = await _restClient.ListOrdersAsync(
+                untilDateTimeExclusive: DateTime.Today.AddDays(-5));
+
+            Assert.NotNull(orders);
+            // Assert.NotEmpty(orders);
+        }
 
         public void Dispose()
         {

--- a/Alpaca.Markets/Alpaca.Markets.csproj
+++ b/Alpaca.Markets/Alpaca.Markets.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard1.6;net45</TargetFrameworks>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.0.3</Version>
+    <Version>3.0.4</Version>
     <RepositoryUrl>https://github.com/alpacahq/alpaca-trade-api-csharp</RepositoryUrl>
     <PackageProjectUrl>https://alpaca.markets/</PackageProjectUrl>
     <Copyright>© 2018 Alpaca Securities LLC. All rights reserved.</Copyright>
@@ -12,8 +12,8 @@
     <Authors>Alpaca Securities LLC</Authors>
     <Product>.NET SDK for Alpaca Trade API</Product>
     <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
-    <AssemblyVersion>3.0.3.0</AssemblyVersion>
-    <FileVersion>3.0.3.0</FileVersion>
+    <AssemblyVersion>3.0.4.0</AssemblyVersion>
+    <FileVersion>3.0.4.0</FileVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>8002;NU5125</NoWarn>
   </PropertyGroup>

--- a/Alpaca.Markets/Alpaca.Markets.csproj
+++ b/Alpaca.Markets/Alpaca.Markets.csproj
@@ -4,16 +4,16 @@
     <TargetFrameworks>netstandard2.0;netstandard1.6;net45</TargetFrameworks>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.0.4</Version>
+    <Version>3.0.5</Version>
     <RepositoryUrl>https://github.com/alpacahq/alpaca-trade-api-csharp</RepositoryUrl>
     <PackageProjectUrl>https://alpaca.markets/</PackageProjectUrl>
-    <Copyright>© 2018 Alpaca Securities LLC. All rights reserved.</Copyright>
+    <Copyright>© 2018-2019 Alpaca Securities LLC. All rights reserved.</Copyright>
     <Company>Alpaca Securities LLC</Company>
     <Authors>Alpaca Securities LLC</Authors>
     <Product>.NET SDK for Alpaca Trade API</Product>
     <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
-    <AssemblyVersion>3.0.4.0</AssemblyVersion>
-    <FileVersion>3.0.4.0</FileVersion>
+    <AssemblyVersion>3.0.5.0</AssemblyVersion>
+    <FileVersion>3.0.5.0</FileVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>8002;NU5125</NoWarn>
   </PropertyGroup>

--- a/Alpaca.Markets/Alpaca.Markets.csproj
+++ b/Alpaca.Markets/Alpaca.Markets.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard1.6;net45</TargetFrameworks>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.0.6</Version>
+    <Version>3.0.7</Version>
     <RepositoryUrl>https://github.com/alpacahq/alpaca-trade-api-csharp</RepositoryUrl>
     <PackageProjectUrl>https://alpaca.markets/</PackageProjectUrl>
     <Copyright>© 2018-2019 Alpaca Securities LLC. All rights reserved.</Copyright>
@@ -12,8 +12,8 @@
     <Authors>Alpaca Securities LLC</Authors>
     <Product>.NET SDK for Alpaca Trade API</Product>
     <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
-    <AssemblyVersion>3.0.6.0</AssemblyVersion>
-    <FileVersion>3.0.6.0</FileVersion>
+    <AssemblyVersion>3.0.7.0</AssemblyVersion>
+    <FileVersion>3.0.7.0</FileVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>8002;NU5125</NoWarn>
   </PropertyGroup>

--- a/Alpaca.Markets/Alpaca.Markets.csproj
+++ b/Alpaca.Markets/Alpaca.Markets.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard1.6;net45</TargetFrameworks>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.0.7</Version>
+    <Version>3.1.0-alpha</Version>
     <RepositoryUrl>https://github.com/alpacahq/alpaca-trade-api-csharp</RepositoryUrl>
     <PackageProjectUrl>https://alpaca.markets/</PackageProjectUrl>
     <Copyright>© 2018-2019 Alpaca Securities LLC. All rights reserved.</Copyright>
@@ -12,8 +12,8 @@
     <Authors>Alpaca Securities LLC</Authors>
     <Product>.NET SDK for Alpaca Trade API</Product>
     <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
-    <AssemblyVersion>3.0.7.0</AssemblyVersion>
-    <FileVersion>3.0.7.0</FileVersion>
+    <AssemblyVersion>3.1.0.0</AssemblyVersion>
+    <FileVersion>3.1.0.0</FileVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>8002;NU5125</NoWarn>
   </PropertyGroup>

--- a/Alpaca.Markets/Alpaca.Markets.csproj
+++ b/Alpaca.Markets/Alpaca.Markets.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard1.6;net45</TargetFrameworks>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.0.5</Version>
+    <Version>3.0.6</Version>
     <RepositoryUrl>https://github.com/alpacahq/alpaca-trade-api-csharp</RepositoryUrl>
     <PackageProjectUrl>https://alpaca.markets/</PackageProjectUrl>
     <Copyright>© 2018-2019 Alpaca Securities LLC. All rights reserved.</Copyright>
@@ -12,8 +12,8 @@
     <Authors>Alpaca Securities LLC</Authors>
     <Product>.NET SDK for Alpaca Trade API</Product>
     <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
-    <AssemblyVersion>3.0.5.0</AssemblyVersion>
-    <FileVersion>3.0.5.0</FileVersion>
+    <AssemblyVersion>3.0.6.0</AssemblyVersion>
+    <FileVersion>3.0.6.0</FileVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>8002;NU5125</NoWarn>
   </PropertyGroup>

--- a/Alpaca.Markets/Enums/OrderListSorting.cs
+++ b/Alpaca.Markets/Enums/OrderListSorting.cs
@@ -1,0 +1,25 @@
+﻿using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Alpaca.Markets
+{
+    /// <summary>
+    /// Order statuses sorting direction for <see cref="RestClient.ListOrdersAsync"/> call from Alpaca REST API.
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum OrderListSorting
+    {
+        /// <summary>
+        /// Returns only open orders.
+        /// </summary>
+        [EnumMember(Value = "desc")]
+        Descending,
+
+        /// <summary>
+        /// Returns only closed orders.
+        /// </summary>
+        [EnumMember(Value = "asc")]
+        Ascending
+    }
+}

--- a/Alpaca.Markets/Helpers/QueryBuilder.cs
+++ b/Alpaca.Markets/Helpers/QueryBuilder.cs
@@ -31,10 +31,17 @@ namespace Alpaca.Markets
         public QueryBuilder AddParameter(
             String name,
             DateTime? value,
-            String format = "O")
+            String format)
         {
             return addParameter(name, value,
-                time => time.ToString(format, CultureInfo.InvariantCulture));
+                time =>
+                {
+                    if (time.Kind == DateTimeKind.Unspecified)
+                    {
+                        time = DateTime.SpecifyKind(time, DateTimeKind.Utc);
+                    }
+                    return time.ToString(format, CultureInfo.InvariantCulture);
+                });
         }
 
         public QueryBuilder AddParameter(

--- a/Alpaca.Markets/RestClient.General.cs
+++ b/Alpaca.Markets/RestClient.General.cs
@@ -58,12 +58,16 @@ namespace Alpaca.Markets
         /// Gets list of available orders from Alpaca REST API endpoint.
         /// </summary>
         /// <param name="orderStatusFilter">Order status for filtering.</param>
-        /// <param name="untilDateTime">Returns only orders until specified date.</param>
+        /// <param name="orderListSorting">The chronological order of response based on the submission time.</param>
+        /// <param name="untilDateTimeExclusive">Returns only orders until specified timestamp (exclusive).</param>
+        /// <param name="afterDateTimeExclusive">Returns only orders after specified timestamp (exclusive).</param>
         /// <param name="limitOrderNumber">Maximal number of orders in response.</param>
         /// <returns>Read-only list of order information objects.</returns>
         public Task<IEnumerable<IOrder>> ListOrdersAsync(
             OrderStatusFilter? orderStatusFilter = null,
-            DateTime? untilDateTime = null,
+            OrderListSorting? orderListSorting = null,
+            DateTime? untilDateTimeExclusive = null,
+            DateTime? afterDateTimeExclusive = null,
             Int64? limitOrderNumber = null)
         {
             var builder = new UriBuilder(_alpacaHttpClient.BaseAddress)
@@ -71,7 +75,9 @@ namespace Alpaca.Markets
                 Path = _alpacaHttpClient.BaseAddress.AbsolutePath + "orders",
                 Query = new QueryBuilder()
                     .AddParameter("status", orderStatusFilter)
-                    .AddParameter("until", untilDateTime)
+                    .AddParameter("direction", orderListSorting)
+                    .AddParameter("until", untilDateTimeExclusive, "O")
+                    .AddParameter("after", afterDateTimeExclusive, "O")
                     .AddParameter("limit", limitOrderNumber)
             };
 
@@ -271,8 +277,8 @@ namespace Alpaca.Markets
                 Path = _alpacaDataClient.BaseAddress.AbsolutePath + $"bars/{timeFrame.ToEnumString()}",
                 Query = new QueryBuilder()
                     .AddParameter("symbols", string.Join(",", symbols))
-                    .AddParameter((areTimesInclusive ? "start" : "after"), timeFrom)
-                    .AddParameter((areTimesInclusive ? "end" : "until"), timeInto)
+                    .AddParameter((areTimesInclusive ? "start" : "after"), timeFrom, "O")
+                    .AddParameter((areTimesInclusive ? "end" : "until"), timeInto, "O")
                     .AddParameter("limit", limit)
             };
 

--- a/Alpaca.Markets/RestClient.Polygon.cs
+++ b/Alpaca.Markets/RestClient.Polygon.cs
@@ -151,8 +151,8 @@ namespace Alpaca.Markets
             {
                 Path = $"v1/historic/agg/minute/{symbol}",
                 Query = getDefaultPolygonApiQueryBuilder()
-                    .AddParameter("from", dateFromInclusive)
-                    .AddParameter("to", dateIntoInclusive)
+                    .AddParameter("from", dateFromInclusive, "O")
+                    .AddParameter("to", dateIntoInclusive, "O")
                     .AddParameter("limit", limit)
             };
 


### PR DESCRIPTION
- Incorrect method used for formatting dates in request URLs for all methods which assume ISO8610 in code - explict format used for all dates parameters now.
- Method `ListOrdersAsync` extended and now it's posible to specify both `until` and `after` exclusive dates (make range) and sorting order for result.