### PR TITLE
Update default Alpaca API version from 1 to 2

### DIFF
--- a/Alpaca.Markets/RestClient.cs
+++ b/Alpaca.Markets/RestClient.cs
@@ -17,7 +17,7 @@ namespace Alpaca.Markets
     /// </summary>
     public sealed partial class RestClient : IDisposable
     {
-        private const Int32 DEFAULT_API_VERSION_NUMBER = 1;
+        private const Int32 DEFAULT_API_VERSION_NUMBER = 2;
         
         private static readonly HashSet<Int32> _supportedApiVersions = new HashSet<Int32> { 1, 2 };
 


### PR DESCRIPTION
New Alpaca accounts now have access to v2 API features, so the default should be updated to v2. @OlegRa, what version number should this be? Does this warrant a major version upgrade for this package?