### PR TITLE
New build configuration approach using Appveyor.yml 

### DIFF
--- a/Alpaca.Markets/Alpaca.Markets.csproj
+++ b/Alpaca.Markets/Alpaca.Markets.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard1.6;net45</TargetFrameworks>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.1.0-alpha</Version>
+    <Version>3.1.0</Version>
     <RepositoryUrl>https://github.com/alpacahq/alpaca-trade-api-csharp</RepositoryUrl>
     <PackageProjectUrl>https://alpaca.markets/</PackageProjectUrl>
     <Copyright>© 2018-2019 Alpaca Securities LLC. All rights reserved.</Copyright>

--- a/Alpaca.Markets/Alpaca.Markets.csproj
+++ b/Alpaca.Markets/Alpaca.Markets.csproj
@@ -12,8 +12,8 @@
     <Authors>Alpaca Securities LLC</Authors>
     <Product>.NET SDK for Alpaca Trade API</Product>
     <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
-    <AssemblyVersion>3.2.0.0</AssemblyVersion>
-    <FileVersion>3.2.0.0</FileVersion>
+    <AssemblyVersion>3.1.1.0</AssemblyVersion>
+    <FileVersion>3.1.1.0</FileVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>8002;NU5125</NoWarn>
   </PropertyGroup>

--- a/Alpaca.Markets/Alpaca.Markets.csproj
+++ b/Alpaca.Markets/Alpaca.Markets.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard1.6;net45</TargetFrameworks>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.1.0</Version>
+    <Version>3.2.0-alpha</Version>
     <RepositoryUrl>https://github.com/alpacahq/alpaca-trade-api-csharp</RepositoryUrl>
     <PackageProjectUrl>https://alpaca.markets/</PackageProjectUrl>
     <Copyright>© 2018-2019 Alpaca Securities LLC. All rights reserved.</Copyright>
@@ -12,8 +12,8 @@
     <Authors>Alpaca Securities LLC</Authors>
     <Product>.NET SDK for Alpaca Trade API</Product>
     <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
-    <AssemblyVersion>3.1.0.0</AssemblyVersion>
-    <FileVersion>3.1.0.0</FileVersion>
+    <AssemblyVersion>3.2.0.0</AssemblyVersion>
+    <FileVersion>3.2.0.0</FileVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>8002;NU5125</NoWarn>
   </PropertyGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,9 +51,8 @@ deploy:
       secure: YYlVeoqkOM5F7xNXiPB52zZITqMG7WAcnqJwRbqFyuJjksrMV+olBl01RN9uFyyA
     artifact: /.*\.nupkg/           # upload all NuGet packages to NuGet
     on:
-      branch: master
+      APPVEYOR_REPO_TAG: true       # deploy on tag push only
 
-    # Deploy to GitHub Releases
   - provider: GitHub
     auth_token:
       secure: 0Gv+Vf6G1OTXyPjYQEPbAS3Ppf3JjVAwXuqCF+lvXfJ5+2EyzbSYUQKmburDzqlM
@@ -62,5 +61,4 @@ deploy:
     draft: true
     prerelease: false
     on:
-      branch: master                # release from master branch only
       APPVEYOR_REPO_TAG: true       # deploy on tag push only

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,11 +4,6 @@
 
 version: 3.2.{build}
 
-branches:
-  only:
-    - master
-    - develop
-
 skip_non_tags: true
 
 #---------------------------------#

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,9 @@ nuget:
 #       build configuration       #
 #---------------------------------#
 
+before_build:
+  - nuget restore
+
 configuration: Release
 
 build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,12 @@ build_script:
   - dotnet build -c Release
 
 #---------------------------------#
+#       tests configuration       #
+#---------------------------------#
+
+test: off
+
+#---------------------------------#
 #      artifacts configuration    #
 #---------------------------------#
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@
 
 version: 3.2.{build}
 
-skip_non_tags: true
+# skip_non_tags: true
 
 #---------------------------------#
 #    environment configuration    #

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,71 @@
+#---------------------------------#
+#      general configuration      #
+#---------------------------------#
+
+version: 3.2.{build}
+
+branches:
+  only:
+    - master
+    - develop
+
+skip_non_tags: true
+
+#---------------------------------#
+#    environment configuration    #
+#---------------------------------#
+
+image: Visual Studio 2017
+
+clone_depth: 5                      # clone entire repository history if not defined
+
+nuget:
+  account_feed: false
+  project_feed: true
+  disable_publish_on_pr: true     # disable publishing of .nupkg artifacts to account/project feeds for pull request builds
+
+#---------------------------------#
+#       build configuration       #
+#---------------------------------#
+
+configuration: Release
+
+build:
+  parallel: true                  # enable MSBuild parallel builds
+  project: Alpaca.Markets.sln     # path to Visual Studio solution or project
+#  publish_core_console: true      # Package .NET Core console projects
+#  publish_nuget: true             # package projects with .nuspec files and push to artifacts
+#  publish_nuget_symbols: true     # generate and publish NuGet symbol packages
+#  include_nuget_references: true  # add -IncludeReferencedProjects option while packaging NuGet artifacts
+#  verbosity: quiet|minimal|normal|detailed
+
+#---------------------------------#
+#      artifacts configuration    #
+#---------------------------------#
+
+artifacts:
+  - path: '**\*.nupkg'
+
+#---------------------------------#
+#     deployment configuration    #
+#---------------------------------#
+
+deploy:
+  - provider: NuGet
+    api_key:
+      secure: YYlVeoqkOM5F7xNXiPB52zZITqMG7WAcnqJwRbqFyuJjksrMV+olBl01RN9uFyyA
+    artifact: /.*\.nupkg/           # upload all NuGet packages to NuGet
+    on:
+      branch: master
+
+    # Deploy to GitHub Releases
+  - provider: GitHub
+    auth_token:
+      secure: 0Gv+Vf6G1OTXyPjYQEPbAS3Ppf3JjVAwXuqCF+lvXfJ5+2EyzbSYUQKmburDzqlM
+    description: Draft release
+    artifact: /.*\.nupkg/           # upload all NuGet packages to release assets
+    draft: true
+    prerelease: false
+    on:
+      branch: master                # release from master branch only
+      APPVEYOR_REPO_TAG: true       # deploy on tag push only

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,19 +23,10 @@ nuget:
 #       build configuration       #
 #---------------------------------#
 
-before_build:
-  - nuget restore
-
 configuration: Release
 
-build:
-  parallel: true                  # enable MSBuild parallel builds
-  project: Alpaca.Markets.sln     # path to Visual Studio solution or project
-#  publish_core_console: true      # Package .NET Core console projects
-#  publish_nuget: true             # package projects with .nuspec files and push to artifacts
-#  publish_nuget_symbols: true     # generate and publish NuGet symbol packages
-#  include_nuget_references: true  # add -IncludeReferencedProjects option while packaging NuGet artifacts
-#  verbosity: quiet|minimal|normal|detailed
+build_sript:
+  - dotnet build -c Release
 
 #---------------------------------#
 #      artifacts configuration    #

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ nuget:
 
 configuration: Release
 
-build_sript:
+build_script:
   - dotnet build -c Release
 
 #---------------------------------#
@@ -51,7 +51,7 @@ deploy:
   - provider: GitHub
     auth_token:
       secure: 0Gv+Vf6G1OTXyPjYQEPbAS3Ppf3JjVAwXuqCF+lvXfJ5+2EyzbSYUQKmburDzqlM
-    description: Draft release
+    description: Draft release {APPVEYOR_REPO_TAG_NAME}
     artifact: /.*\.nupkg/           # upload all NuGet packages to release assets
     draft: true
     prerelease: false


### PR DESCRIPTION
Fix for issue #57 - it's better to place all build parameters into code. This approach allows us to run same build using different Appveyor accounts. For triggering build right now we have to add tag and push it into origin repo. If we need build on each commit we can do by removing single line of code from Appveyor.yml file.