### PR TITLE
Add new supported order types to enum

### DIFF
--- a/Alpaca.Markets/Enums/TimeInForce.cs
+++ b/Alpaca.Markets/Enums/TimeInForce.cs
@@ -38,6 +38,18 @@ namespace Alpaca.Markets
         /// The order is immediately filled or canceled after being placed (may not partial fill).
         /// </summary>
         [EnumMember(Value = "fok")]
-        Fok
+        Fok,
+
+        /// <summary>
+        /// The order will become a market order at market close.
+        /// </summary>
+        [EnumMember(Value = "moc")]
+        Moc,
+
+        /// <summary>
+        /// The order will become a limit order at the market's closing price at market close.
+        /// </summary>
+        [EnumMember(Value = "loc")]
+        Loc,
     }
 }


### PR DESCRIPTION
MOC and LOC support was just added to the Alpaca API this week - this PR will let people use them via the OrderType enum.