### PR TITLE
Add endpoint to delete all open orders

### DIFF
--- a/Alpaca.Markets/RestClient.General.cs
+++ b/Alpaca.Markets/RestClient.General.cs
@@ -187,13 +187,27 @@ namespace Alpaca.Markets
         /// Deletes/cancel order on server by server order ID using Alpaca REST API endpoint.
         /// </summary>
         /// <param name="orderId">Server order ID for cancelling.</param>
-        /// <returns><c>True</c> if order deleted/cancelled successfully.</returns>
+        /// <returns><c>True</c> if order cancellation was accepted.</returns>
         public async Task<Boolean> DeleteOrderAsync(
             Guid orderId)
         {
             await _alpacaRestApiThrottler.WaitToProceed();
 
             using (var response = await _alpacaHttpClient.DeleteAsync($"orders/{orderId:D}"))
+            {
+                return response.IsSuccessStatusCode;
+            }
+        }
+
+        /// <summary>
+        /// Deletes/cancel all open orders using Alpaca REST API endpoint.
+        /// </summary>
+        /// <returns><c>True</c> if order deleted/cancelled successfully.</returns>
+        public async Task<Boolean> DeleteAllOrdersAsync()
+        {
+            await _alpacaRestApiThrottler.WaitToProceed();
+
+            using (var response = await _alpacaHttpClient.DeleteAsync($"orders"))
             {
                 return response.IsSuccessStatusCode;
             }


### PR DESCRIPTION
https://docs.alpaca.markets/api-documentation/api-v2/orders/

In the future, we might change this to parse out the multi-body response and return a `Dictionary<String, Boolean>` indicating whether or not each order was successfully canceled, but I think most use cases of this endpoint will be satisfied simply knowing whether or not the request itself was accepted.