### PR TITLE
Fix erroneous on-close TIF values

### DIFF
--- a/Alpaca.Markets/Enums/TimeInForce.cs
+++ b/Alpaca.Markets/Enums/TimeInForce.cs
@@ -43,13 +43,13 @@ namespace Alpaca.Markets
         /// <summary>
         /// The order will become a market order at market close.
         /// </summary>
-        [EnumMember(Value = "moc")]
+        [EnumMember(Value = "cls")]
         Moc,
 
         /// <summary>
         /// The order will become a limit order at the market's closing price at market close.
         /// </summary>
-        [EnumMember(Value = "loc")]
+        [EnumMember(Value = "cls")]
         Loc,
     }
 }

--- a/Alpaca.Markets/Enums/TimeInForce.cs
+++ b/Alpaca.Markets/Enums/TimeInForce.cs
@@ -41,15 +41,9 @@ namespace Alpaca.Markets
         Fok,
 
         /// <summary>
-        /// The order will become a market order at market close.
+        /// The order will become a limit order if a limit price is specified or a market order otherwise at market close.
         /// </summary>
         [EnumMember(Value = "cls")]
-        Moc,
-
-        /// <summary>
-        /// The order will become a limit order at the market's closing price at market close.
-        /// </summary>
-        [EnumMember(Value = "cls")]
-        Loc,
+        Cls,
     }
 }


### PR DESCRIPTION
When I added the new MOC/LOC time-in-force values, I was under the impression that they were distinct on the backend. However, both should actually equate to simply "cls" in the API request. I've left them distinct in the enum for the sake of readability in user algorithms, but I'm open to reducing them down to just one `TimeInForce.Cls` value instead if people prefer it that way.

The documentation has been updated with the new TIF here confirming the cls value: https://docs.alpaca.markets/orders/#time-in-force