### PR TITLE
Fix OrderStatus enumerator

### DIFF
--- a/Alpaca.Markets/Enums/OrderStatus.cs
+++ b/Alpaca.Markets/Enums/OrderStatus.cs
@@ -23,9 +23,15 @@ namespace Alpaca.Markets
         New,
 
         /// <summary>
-        /// Order partially filled.
+        /// Partial fill (event) on order.
         /// </summary>
         [EnumMember(Value = "partial_fill")]
+        PartialFill,
+
+        /// <summary>
+        /// Order partially filled (status).
+        /// </summary>
+        [EnumMember(Value = "partially_filled")]
         PartiallyFilled,
 
         /// <summary>


### PR DESCRIPTION
We need both `PartiallFill` and `PartialyFilled` enum members.