### PR TITLE
Issue #88 - incoming messages dispatching logic changed.

### DIFF
--- a/Alpaca.Markets/Helpers/ActionExtensions.cs
+++ b/Alpaca.Markets/Helpers/ActionExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Newtonsoft.Json.Linq;
+
+namespace Alpaca.Markets
+{
+    internal static class ActionExtensions
+    {
+        public static void Invoke<TApi, TJson>(
+            this Action<TApi> eventHandler,
+            JToken eventArg)
+            where TJson : class, TApi
+        {
+            eventHandler?.Invoke(eventArg.ToObject<TJson>());
+        }
+    }
+}

--- a/Alpaca.Markets/PolygonSockClient.cs
+++ b/Alpaca.Markets/PolygonSockClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json.Linq;
 
@@ -13,7 +14,7 @@ namespace Alpaca.Markets
     // ReSharper disable once PartialTypeWithSinglePart
     public sealed partial class PolygonSockClient : SockClientBase
     {
-        // Available Polygon channels
+        // Available Polygon message types
 
         // ReSharper disable InconsistentNaming
 
@@ -28,6 +29,8 @@ namespace Alpaca.Markets
         private const String StatusMessage = "status";
 
         // ReSharper restore InconsistentNaming
+
+        private readonly IDictionary<String, Action<JToken>> _handlers;
 
         private readonly String _keyId;
         
@@ -99,6 +102,15 @@ namespace Alpaca.Markets
             {
                 _keyId += "-staging";
             }
+
+            _handlers = new Dictionary<string, Action<JToken>>(StringComparer.Ordinal)
+            {
+                { StatusMessage, handleAuthorization },
+                { TradesChannel, handleTradesChannel },
+                { QuotesChannel, handleQuotesChannel },
+                { MinuteAggChannel, handleMinuteAggChannel },
+                { SecondAggChannel, handleSecondAggChannel }
+            };
         }
 
         /// <summary>
@@ -182,39 +194,9 @@ namespace Alpaca.Markets
         {
             try
             {
-                var rootArray = JArray.Parse(message);
-
-                foreach (var root in rootArray)
+                foreach (var token in JArray.Parse(message))
                 {
-                    var stream = root["ev"].ToString();
-
-                    switch (stream)
-                    {
-                        case TradesChannel:
-                            TradeReceived?.Invoke(root.ToObject<JsonStreamTrade>());
-                            break;
-
-                        case QuotesChannel:
-                            QuoteReceived?.Invoke(root.ToObject<JsonStreamQuote>());
-                            break;
-
-                        case MinuteAggChannel:
-                            MinuteAggReceived?.Invoke(root.ToObject<JsonStreamAgg>());
-                            break;
-
-                        case SecondAggChannel:
-                            SecondAggReceived?.Invoke(root.ToObject<JsonStreamAgg>());
-                            break;
-
-                        case StatusMessage:
-                            handleAuthorization(root.ToObject<JsonConnectionStatus>());
-                            break;
-
-                        default:
-                            HandleError(new InvalidOperationException(
-                                $"Unexpected message type '{stream}' received."));
-                            break;
-                    }
+                    HandleMessage(_handlers, token["ev"].ToString(), token);
                 }
             }
             catch (Exception exception)
@@ -236,8 +218,10 @@ namespace Alpaca.Markets
         }
 
         private void handleAuthorization(
-            JsonConnectionStatus connectionStatus)
+            JToken token)
         {
+            var connectionStatus = token.ToObject<JsonConnectionStatus>();
+
             switch (connectionStatus.Status)
             {
                 case ConnectionStatus.Connected:
@@ -287,5 +271,21 @@ namespace Alpaca.Markets
 
             SendAsJsonString(unsubscribeRequest);
         }
+
+        private void handleTradesChannel(
+            JToken token) =>
+            TradeReceived.Invoke<IStreamTrade, JsonStreamTrade>(token);
+
+        private void handleQuotesChannel(
+            JToken token) =>
+            QuoteReceived.Invoke<IStreamQuote, JsonStreamQuote>(token);
+
+        private void handleMinuteAggChannel(
+            JToken token) =>
+            MinuteAggReceived.Invoke<IStreamAgg, JsonStreamAgg>(token);
+
+        private void handleSecondAggChannel(
+            JToken token) =>
+            SecondAggReceived.Invoke<IStreamAgg, JsonStreamAgg>(token);
     }
 }

--- a/Alpaca.Markets/SockClient.cs
+++ b/Alpaca.Markets/SockClient.cs
@@ -15,6 +15,22 @@ namespace Alpaca.Markets
     // ReSharper disable once PartialTypeWithSinglePart
     public sealed partial class SockClient : SockClientBase
     {
+        // Available Alpaca message types
+
+        // ReSharper disable InconsistentNaming
+
+        private const String TradeUpdates = "trade_updates";
+
+        private const String AccountUpdates = "account_updates";
+
+        private const String Authorization = "authorization";
+
+        private const String Listening = "listening";
+
+        // ReSharper restore InconsistentNaming
+
+        private readonly IDictionary<String, Action<JToken>> _handlers;
+
         private readonly String _keyId;
 
         private readonly String _secretKey;
@@ -57,6 +73,14 @@ namespace Alpaca.Markets
                          "Application key id should not be null", nameof(keyId));
             _secretKey = secretKey ?? throw new ArgumentException(
                              "Application secret key should not be null", nameof(secretKey));
+
+            _handlers = new Dictionary<string, Action<JToken>>(StringComparer.Ordinal)
+            {
+                { Listening, _ => { } },
+                { Authorization, handleAuthorization },
+                { AccountUpdates, handleAccountUpdate },
+                { TradeUpdates, handleTradeUpdate }
+            };
         }
 
         /// <summary>
@@ -99,38 +123,8 @@ namespace Alpaca.Markets
         {
             try
             {
-                var message = Encoding.UTF8.GetString(binaryData);
-                var root = JObject.Parse(message);
-
-                var data = root["data"];
-                var stream = root["stream"].ToString();
-
-                switch (stream)
-                {
-                    case "authorization":
-                        handleAuthorization(
-                            data.ToObject<JsonAuthResponse>());
-                        break;
-
-                    case "listening":
-                        Connected?.Invoke(AuthStatus.Authorized);
-                        break;
-
-                    case "trade_updates":
-                        handleTradeUpdates(
-                            data.ToObject<JsonTradeUpdate>());
-                        break;
-
-                    case "account_updates":
-                        handleAccountUpdates(
-                            data.ToObject<JsonAccountUpdate>());
-                        break;
-
-                    default:
-                        HandleError(new InvalidOperationException(
-                            $"Unexpected message type '{stream}' received."));
-                        break;
-                }
+                var token = JObject.Parse(Encoding.UTF8.GetString(binaryData));
+                HandleMessage(_handlers, token["stream"].ToString(), token["data"]);
             }
             catch (Exception exception)
             {
@@ -158,8 +152,10 @@ namespace Alpaca.Markets
         }
 
         private void handleAuthorization(
-            JsonAuthResponse response)
+            JToken token)
         {
+            var response = token.ToObject<JsonAuthResponse>();
+
             if (response.Status == AuthStatus.Authorized)
             {
                 var listenRequest = new JsonListenRequest
@@ -169,8 +165,8 @@ namespace Alpaca.Markets
                     {
                         Streams = new List<String>
                         {
-                            "trade_updates",
-                            "account_updates"
+                            TradeUpdates,
+                            AccountUpdates
                         }
                     }
                 };
@@ -183,16 +179,12 @@ namespace Alpaca.Markets
             }
         }
 
-        private void handleTradeUpdates(
-            ITradeUpdate update)
-        {
-            OnTradeUpdate?.Invoke(update);
-        }
+        private void handleTradeUpdate(
+            JToken token) =>
+            OnTradeUpdate.Invoke<ITradeUpdate, JsonTradeUpdate>(token);
 
-        private void handleAccountUpdates(
-            IAccountUpdate update)
-        {
-            OnAccountUpdate?.Invoke(update);
-        }
+        private void handleAccountUpdate(
+            JToken token) =>
+            OnAccountUpdate.Invoke<IAccountUpdate, JsonAccountUpdate>(token);
     }
 }


### PR DESCRIPTION
Each `SockClient` and `PolygonSockClient` class now contains `_handlers` map which maps incoming message type (decoded as string) to generic handler method. Handler method gets single `JToken` parameter, deserialize it and process as expected. `SockClientBase` class contains helper method `HandlerMessage` for proper map, message type and message data processing and exceptions handling via `OnError` event.