### PR TITLE
Issue #107 -  add cancellation support into asynchronous methods

### DIFF
--- a/Alpaca.Markets/Alpaca.Markets.csproj
+++ b/Alpaca.Markets/Alpaca.Markets.csproj
@@ -19,9 +19,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIconUrl>https://alpaca.markets/static/favicon-32x32.png</PackageIconUrl>
     <Description>C# SDK for Alpaca Trade API https://docs.alpaca.markets/</Description>
-    <PackageReleaseNotes>- Method `ConnectAndAuthenticateAsync` added into both Web Socket clients
-- Class `PolygonSockClient` now contains methods for batch (un)subscription
-- Method `DeleteAllOrdersAsync` returns deletion status for each order now</PackageReleaseNotes>
+    <PackageReleaseNotes>- All asynchronous methods get optional `CancellationToken` argument now</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Alpaca.Markets/FakeThrottler.cs
+++ b/Alpaca.Markets/FakeThrottler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Alpaca.Markets
@@ -20,9 +21,9 @@ namespace Alpaca.Markets
         public HashSet<Int32> RetryHttpStatuses { get; set; } = new HashSet<Int32>();
 
 #if NET45
-        public Task WaitToProceed() => _completedTask.Value;
+        public Task WaitToProceed(CancellationToken _) => _completedTask.Value;
 #else
-        public Task WaitToProceed() => Task.CompletedTask;
+        public Task WaitToProceed(CancellationToken _) => Task.CompletedTask;
 #endif
 
         public Boolean CheckHttpResponse(HttpResponseMessage response) => true;

--- a/Alpaca.Markets/IThrottler.cs
+++ b/Alpaca.Markets/IThrottler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Alpaca.Markets
@@ -14,7 +15,9 @@ namespace Alpaca.Markets
         /// <summary>
         /// Blocks the current thread indefinitely until allowed to proceed.
         /// </summary>
-        Task WaitToProceed();
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        Task WaitToProceed(
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Evaluates the StatusCode of <paramref name="response"/>, initiates any server requested delays, 
@@ -27,6 +30,7 @@ namespace Alpaca.Markets
         /// <exception cref="HttpRequestException">
         /// The HTTP response is unsuccessful, and caller did not indicate that requests with this StatusCode should be retried.
         /// </exception>
-        Boolean CheckHttpResponse(HttpResponseMessage response);
+        Boolean CheckHttpResponse(
+            HttpResponseMessage response);
     }
 }

--- a/Alpaca.Markets/RateThrottler.cs
+++ b/Alpaca.Markets/RateThrottler.cs
@@ -22,7 +22,8 @@ namespace Alpaca.Markets
 
             private DateTime _nextRetryTime = DateTime.MinValue;
 
-            public async Task WaitToProceed()
+            public async Task WaitToProceed(
+                CancellationToken cancellationToken)
             {
                 var delay = GetDelayTillNextRetryTime();
 
@@ -31,7 +32,7 @@ namespace Alpaca.Markets
                     return;
                 }
 
-                await Task.Delay(delay).ConfigureAwait(false);
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
             }
 
             public void SetNextRetryTimeRandom()
@@ -41,7 +42,8 @@ namespace Alpaca.Markets
                     _randomRetryWait.Next(1000, 5000)));
             }
 
-            public void SetNextRetryTime(DateTime nextRetryTime)
+            public void SetNextRetryTime(
+                DateTime nextRetryTime)
             {
                 if (nextRetryTime < DateTime.UtcNow)
                 {
@@ -141,9 +143,10 @@ namespace Alpaca.Markets
         public Int32 MaxRetryAttempts { get;}
 
         /// <inheritdoc />
-        public async Task WaitToProceed()
+        public async Task WaitToProceed(
+            CancellationToken cancellationToken)
         {
-            await _nextRetryGuard.WaitToProceed().ConfigureAwait(false);
+            await _nextRetryGuard.WaitToProceed(cancellationToken).ConfigureAwait(false);
 
             // Block until we can enter the semaphore or until the timeout expires.
             var entered = _throttleSemaphore.Wait(Timeout.Infinite);
@@ -159,7 +162,8 @@ namespace Alpaca.Markets
 
         // Callback for the exit timer that exits the semaphore based on exit times 
         // in the queue and then sets the timer for the next exit time.
-        private void exitTimerCallback(Object state)
+        private void exitTimerCallback(
+            Object state)
         {
             var nextRetryDelay = _nextRetryGuard.GetDelayTillNextRetryTime().TotalMilliseconds;
             if (nextRetryDelay > 0)
@@ -191,7 +195,8 @@ namespace Alpaca.Markets
         }
 
         /// <inheritdoc />
-        public Boolean CheckHttpResponse(HttpResponseMessage response)
+        public Boolean CheckHttpResponse(
+            HttpResponseMessage response)
         {
             // Adhere to server reported instructions
             if (response.StatusCode == HttpStatusCode.OK)

--- a/Alpaca.Markets/RestClient.Polygon.cs
+++ b/Alpaca.Markets/RestClient.Polygon.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Alpaca.Markets
@@ -9,10 +10,12 @@ namespace Alpaca.Markets
     public sealed partial class RestClient
     {
         /// <summary>
-        /// Gets list of available exchanes from Polygon REST API endpoint.
+        /// Gets list of available exchanges from Polygon REST API endpoint.
         /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>Read-only list of exchange information objects.</returns>
-        public Task<IEnumerable<IExchange>> ListExchangesAsync()
+        public Task<IEnumerable<IExchange>> ListExchangesAsync(
+            CancellationToken cancellationToken = default)
         {
             var builder = new UriBuilder(_polygonHttpClient.BaseAddress)
             {
@@ -21,17 +24,19 @@ namespace Alpaca.Markets
             };
 
             return getObjectsListAsync<IExchange, JsonExchange>(
-                _polygonHttpClient, FakeThrottler.Instance, builder);
+                _polygonHttpClient, FakeThrottler.Instance, builder, cancellationToken);
         }
 
         /// <summary>
         /// Gets mapping dictionary for symbol types from Polygon REST API endpoint.
         /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>
         /// Read-only dictionary with keys equal to symbol type abbreviation and values
         /// equal to full symbol type names descriptions for each supported symbol type.
         /// </returns>
-        public Task<IReadOnlyDictionary<String, String>> GetSymbolTypeMapAsync()
+        public Task<IReadOnlyDictionary<String, String>> GetSymbolTypeMapAsync(
+        CancellationToken cancellationToken = default)
         {
             var builder = new UriBuilder(_polygonHttpClient.BaseAddress)
             {
@@ -41,7 +46,7 @@ namespace Alpaca.Markets
 
             return getSingleObjectAsync
                 <IReadOnlyDictionary<String,String>, Dictionary<String, String>>(
-                    _polygonHttpClient, FakeThrottler.Instance, builder);
+                    _polygonHttpClient, FakeThrottler.Instance, builder, cancellationToken);
         }
 
         /// <summary>
@@ -51,12 +56,14 @@ namespace Alpaca.Markets
         /// <param name="date">Single date for data retrieval.</param>
         /// <param name="offset">Paging - offset or first historical trade in days trades llist.</param>
         /// <param name="limit">Paging - maximal number of historical trades in data response.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>Read-only list of historical trade information.</returns>
         public Task<IDayHistoricalItems<IHistoricalTrade>> ListHistoricalTradesAsync(
             String symbol,
             DateTime date,
             Int64? offset = null,
-            Int32? limit = null)
+            Int32? limit = null,
+            CancellationToken cancellationToken = default)
         {
             var dateAsString = date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
             var builder = new UriBuilder(_polygonHttpClient.BaseAddress)
@@ -70,7 +77,7 @@ namespace Alpaca.Markets
             return getSingleObjectAsync
                 <IDayHistoricalItems<IHistoricalTrade>,
                     JsonDayHistoricalItems<IHistoricalTrade, JsonHistoricalTrade>>(
-                _polygonHttpClient, FakeThrottler.Instance, builder);
+                _polygonHttpClient, FakeThrottler.Instance, builder, cancellationToken);
         }
 
         /// <summary>
@@ -80,12 +87,14 @@ namespace Alpaca.Markets
         /// <param name="date">Single date for data retrieval.</param>
         /// <param name="offset">Paging - offset or first historical quote in days quotes llist.</param>
         /// <param name="limit">Paging - maximal number of historical quotes in data response.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>Read-only list of historical quote information.</returns>
         public Task<IDayHistoricalItems<IHistoricalQuote>> ListHistoricalQuotesAsync(
             String symbol,
             DateTime date,
             Int64? offset = null,
-            Int32? limit = null)
+            Int32? limit = null,
+            CancellationToken cancellationToken = default)
         {
             var dateAsString = date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
             var builder = new UriBuilder(_polygonHttpClient.BaseAddress)
@@ -99,7 +108,7 @@ namespace Alpaca.Markets
             return getSingleObjectAsync
                 <IDayHistoricalItems<IHistoricalQuote>,
                     JsonDayHistoricalItems<IHistoricalQuote, JsonHistoricalQuote>>(
-                _polygonHttpClient, FakeThrottler.Instance, builder);
+                _polygonHttpClient, FakeThrottler.Instance, builder, cancellationToken);
         }
 
         /// <summary>
@@ -109,13 +118,15 @@ namespace Alpaca.Markets
         /// <param name="dateFromInclusive">Start time for filtering (inclusive).</param>
         /// <param name="dateIntoInclusive">End time for filtering (inclusive).</param>
         /// <param name="limit">Maximal number of daily bars in data response.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>Read-only list of daily bars for specified asset.</returns>
         [Obsolete("This version of ListDayAggregatesAsync will be deprecated in a future release.")]
         public Task<IAggHistoricalItems<IAgg>> ListDayAggregatesAsync(
             String symbol,
             DateTime? dateFromInclusive = null,
             DateTime? dateIntoInclusive = null,
-            Int32? limit = null)
+            Int32? limit = null,
+            CancellationToken cancellationToken = default)
         {
             var builder = new UriBuilder(_polygonHttpClient.BaseAddress)
             {
@@ -129,7 +140,7 @@ namespace Alpaca.Markets
             return getSingleObjectAsync
                 <IAggHistoricalItems<IAgg>,
                     JsonAggHistoricalItems<IAgg, JsonDayAgg>>(
-                _polygonHttpClient, FakeThrottler.Instance, builder);
+                _polygonHttpClient, FakeThrottler.Instance, builder, cancellationToken);
         }
 
         /// <summary>
@@ -139,13 +150,15 @@ namespace Alpaca.Markets
         /// <param name="dateFromInclusive">Start time for filtering (inclusive).</param>
         /// <param name="dateIntoInclusive">End time for filtering (inclusive).</param>
         /// <param name="limit">Maximal number of minute bars in data response.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>Read-only list of minute bars for specified asset.</returns>
         [Obsolete("This version of ListMinuteAggregatesAsync will be deprecated in a future release.")]
         public Task<IAggHistoricalItems<IAgg>> ListMinuteAggregatesAsync(
             String symbol,
             DateTime? dateFromInclusive = null,
             DateTime? dateIntoInclusive = null,
-            Int32? limit = null)
+            Int32? limit = null,
+            CancellationToken cancellationToken = default)
         {
             var builder = new UriBuilder(_polygonHttpClient.BaseAddress)
             {
@@ -159,7 +172,7 @@ namespace Alpaca.Markets
             return getSingleObjectAsync
                 <IAggHistoricalItems<IAgg>,
                     JsonAggHistoricalItems<IAgg, JsonMinuteAgg>>(
-                _polygonHttpClient, FakeThrottler.Instance, builder);
+                _polygonHttpClient, FakeThrottler.Instance, builder, cancellationToken);
         }
 
         /// <summary>
@@ -170,13 +183,15 @@ namespace Alpaca.Markets
         /// <param name="dateFromInclusive">Start time for filtering (inclusive).</param>
         /// <param name="dateToInclusive">End time for filtering (inclusive).</param>
         /// <param name="unadjusted">Set to true if the results should not be adjusted for splits.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>Read-only list of minute bars for specified asset.</returns>
         public Task<IHistoricalItems<IAgg>> ListMinuteAggregatesAsync(
             String symbol,
             Int32 multiplier,
             DateTime dateFromInclusive,
             DateTime dateToInclusive,
-            Boolean unadjusted = false)
+            Boolean unadjusted = false,
+            CancellationToken cancellationToken = default)
         {
             var unixFrom = DateTimeHelper.GetUnixTimeMilliseconds(dateFromInclusive);
             var unixTo = DateTimeHelper.GetUnixTimeMilliseconds(dateToInclusive);
@@ -191,7 +206,7 @@ namespace Alpaca.Markets
             return getSingleObjectAsync
                 <IHistoricalItems<IAgg>,
                     JsonHistoricalItems<IAgg, JsonMinuteAgg>>(
-                _polygonHttpClient, FakeThrottler.Instance, builder);
+                _polygonHttpClient, FakeThrottler.Instance, builder, cancellationToken);
         }
 
         /// <summary>
@@ -202,13 +217,15 @@ namespace Alpaca.Markets
         /// <param name="dateFromInclusive">Start time for filtering (inclusive).</param>
         /// <param name="dateToInclusive">End time for filtering (inclusive).</param>
         /// <param name="unadjusted">Set to true if the results should not be adjusted for splits.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>Read-only list of day bars for specified asset.</returns>
         public Task<IHistoricalItems<IAgg>> ListDayAggregatesAsync(
             String symbol,
             Int32 multiplier,
             DateTime dateFromInclusive,
             DateTime dateToInclusive,
-            Boolean unadjusted = false)
+            Boolean unadjusted = false,
+            CancellationToken cancellationToken = default)
         {
             var unixFrom = DateTimeHelper.GetUnixTimeMilliseconds(dateFromInclusive);
             var unixTo = DateTimeHelper.GetUnixTimeMilliseconds(dateToInclusive);
@@ -223,16 +240,18 @@ namespace Alpaca.Markets
             return getSingleObjectAsync
                 <IHistoricalItems<IAgg>,
                     JsonHistoricalItems<IAgg, JsonMinuteAgg>>(
-                _polygonHttpClient, FakeThrottler.Instance, builder);
+                _polygonHttpClient, FakeThrottler.Instance, builder, cancellationToken);
         }
 
         /// <summary>
         /// Gets last trade for singe asset from Polygon REST API endpoint.
         /// </summary>
         /// <param name="symbol">Asset name for data retrieval.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>Read-only last trade information.</returns>
         public Task<ILastTrade> GetLastTradeAsync(
-            String symbol)
+            String symbol,
+            CancellationToken cancellationToken = default)
         {
             var builder = new UriBuilder(_polygonHttpClient.BaseAddress)
             {
@@ -241,16 +260,18 @@ namespace Alpaca.Markets
             };
 
             return getSingleObjectAsync<ILastTrade, JsonLastTrade>(
-                _polygonHttpClient, FakeThrottler.Instance, builder);
+                _polygonHttpClient, FakeThrottler.Instance, builder, cancellationToken);
         }
 
         /// <summary>
         /// Gets current quote for singe asset from Polygon REST API endpoint.
         /// </summary>
         /// <param name="symbol">Asset name for data retrieval.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>Read-only current quote information.</returns>
         public Task<ILastQuote> GetLastQuoteAsync(
-            String symbol)
+            String symbol,
+            CancellationToken cancellationToken = default)
         {
             var builder = new UriBuilder(_polygonHttpClient.BaseAddress)
             {
@@ -259,19 +280,21 @@ namespace Alpaca.Markets
             };
 
             return getSingleObjectAsync<ILastQuote, JsonLastQuote>(
-                _polygonHttpClient, FakeThrottler.Instance, builder);
+                _polygonHttpClient, FakeThrottler.Instance, builder, cancellationToken);
         }
 
         /// <summary>
         /// Gets mapping dictionary for specific tick type from Polygon REST API endpoint.
         /// </summary>
         /// <param name="tickType">Tick type for conditions map.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>
         /// Read-only dictionary with keys equal to condition integer values and values
         /// equal to full tick condition descriptions for each supported tick type.
         /// </returns>
         public async Task<IReadOnlyDictionary<Int64, String>> GetConditionMapAsync(
-            TickType tickType = TickType.Trades)
+            TickType tickType = TickType.Trades,
+            CancellationToken cancellationToken = default)
         {
             var builder = new UriBuilder(_polygonHttpClient.BaseAddress)
             {
@@ -281,7 +304,7 @@ namespace Alpaca.Markets
 
             var dictionary = await getSingleObjectAsync
                 <IDictionary<String, String>, Dictionary<String, String>>(
-                    _polygonHttpClient, FakeThrottler.Instance, builder)
+                    _polygonHttpClient, FakeThrottler.Instance, builder, cancellationToken)
                 .ConfigureAwait(false);
 
             return dictionary

--- a/Alpaca.Markets/SockClientBase.cs
+++ b/Alpaca.Markets/SockClientBase.cs
@@ -58,19 +58,24 @@ namespace Alpaca.Markets
         /// <summary>
         /// Opens connection to a streaming API.
         /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>Awaitable task object for handling action completion in asynchronous mode.</returns>
-        public Task ConnectAsync() => _webSocket.OpenAsync();
+        public Task ConnectAsync(
+            CancellationToken cancellationToken = default)
+            => _webSocket.OpenAsync(cancellationToken);
 
         /// <summary>
         /// Opens connection to a streaming API and awaits for authentication response.
         /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>Awaitable task object for handling client authentication event in asynchronous mode.</returns>
-        public async Task<AuthStatus> ConnectAndAuthenticateAsync()
+        public async Task<AuthStatus> ConnectAndAuthenticateAsync(
+            CancellationToken cancellationToken = default)
         {
             var tcs = new TaskCompletionSource<AuthStatus>();
             Connected += handleConnected;
 
-            await ConnectAsync().ConfigureAwait(false);
+            await ConnectAsync(cancellationToken).ConfigureAwait(false);
             return await tcs.Task.ConfigureAwait(false);
 
             void handleConnected(AuthStatus authStatus)
@@ -83,8 +88,11 @@ namespace Alpaca.Markets
         /// <summary>
         /// Closes connection to a streaming API.
         /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>Awaitable task object for handling action completion in asynchronous mode.</returns>
-        public Task DisconnectAsync() => _webSocket.CloseAsync();
+        public Task DisconnectAsync(
+            CancellationToken cancellationToken = default)
+            => _webSocket.CloseAsync(cancellationToken);
 
         /// <inheritdoc />
         public void Dispose()

--- a/Alpaca.Markets/WebSocket/IWebSocket.cs
+++ b/Alpaca.Markets/WebSocket/IWebSocket.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Alpaca.Markets
@@ -13,15 +14,19 @@ namespace Alpaca.Markets
         /// Opens web socket communication channel. Connection state changes will be reported
         /// using <see cref="Opened"/> event and errors - using <see cref="Error"/> event.
         /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>Connection opening task for awaiting (if needed).</returns>
-        Task OpenAsync();
+        Task OpenAsync(
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Closes web socket communication channel. Connection state changes will be reported
         /// using <see cref="Closed"/> event and errors - using <see cref="Error"/> event.
         /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>Connection closing task for awaiting (if needed).</returns>
-        Task CloseAsync();
+        Task CloseAsync(
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Sends text message into opened web socket connection.

--- a/Alpaca.Markets/WebSocket/WebSocket4NetFactory.cs
+++ b/Alpaca.Markets/WebSocket/WebSocket4NetFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Security.Authentication;
+using System.Threading;
 using System.Threading.Tasks;
 using SuperSocket.ClientEngine;
 using WebSocket4Net;
@@ -45,16 +46,18 @@ namespace Alpaca.Markets
                 _webSocket.Dispose();
             }
 
-            public Task OpenAsync() =>
+            public Task OpenAsync(
+                CancellationToken cancellationToken) =>
 #if NET45
-                Task.Run(() => _webSocket.Open());
+                Task.Run(() => _webSocket.Open(), cancellationToken);
 #else
                 _webSocket.OpenAsync();
 #endif
 
-            public Task CloseAsync() =>
+            public Task CloseAsync(
+                CancellationToken cancellationToken) =>
 #if NET45
-                Task.Run(() => _webSocket.Close());
+                Task.Run(() => _webSocket.Close(), cancellationToken);
 #else
                 _webSocket.CloseAsync();
 #endif

--- a/Alpaca.Markets/WebSocket/WebSocketSharpFactory.cs
+++ b/Alpaca.Markets/WebSocket/WebSocketSharpFactory.cs
@@ -4,6 +4,7 @@ using System.Security.Authentication;
 using System.Threading.Tasks;
 using System.Diagnostics.CodeAnalysis;
 using WebSocketSharp;
+using System.Threading;
 
 namespace Alpaca.Markets
 {
@@ -50,9 +51,13 @@ namespace Alpaca.Markets
                 disposable?.Dispose();
             }
 
-            public Task OpenAsync() => Task.Run(() => _webSocket.Connect());
+            public Task OpenAsync(
+                CancellationToken cancellationToken)
+                => Task.Run(() => _webSocket.Connect(), cancellationToken);
 
-            public Task CloseAsync() => Task.Run(() => _webSocket.Close());
+            public Task CloseAsync(
+                CancellationToken cancellationToken)
+                => Task.Run(() => _webSocket.Close(), cancellationToken);
 
             public void Send(
                 String message) =>


### PR DESCRIPTION
All public asynchronous methods get optional `CancellationToken` argument now.