### PR TITLE
Issue #130 - implement account configuration support

### DIFF
--- a/Alpaca.Markets/Enums/DayTradeMarginCallProtection.cs
+++ b/Alpaca.Markets/Enums/DayTradeMarginCallProtection.cs
@@ -1,0 +1,32 @@
+﻿using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Alpaca.Markets
+{
+    /// <summary>
+    /// Day trade margin call protection mode for account. See more information here:
+    /// https://docs.alpaca.markets/user-protections/#day-trade-margin-call-dtmc-protection-at-alpaca
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum DayTradeMarginCallProtection
+    {
+        /// <summary>
+        /// Check rules on position entry.
+        /// </summary>
+        [EnumMember(Value = "entry")]
+        Entry,
+
+        /// <summary>
+        /// Check rules on position exit.
+        /// </summary>
+        [EnumMember(Value = "exit")]
+        Exit,
+
+        /// <summary>
+        /// Check rules on position entry and exit.
+        /// </summary>
+        [EnumMember(Value = "both")]
+        Both,
+    }
+}

--- a/Alpaca.Markets/Enums/TradeConfirmEmail.cs
+++ b/Alpaca.Markets/Enums/TradeConfirmEmail.cs
@@ -1,0 +1,25 @@
+﻿using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Alpaca.Markets
+{
+    /// <summary>
+    /// Notification level for order fill emails.
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum TradeConfirmEmail
+    {
+        /// <summary>
+        /// Never send email notification for order fills.
+        /// </summary>
+        [EnumMember(Value = "none")]
+        None,
+
+        /// <summary>
+        /// Send email notification for all order fills.
+        /// </summary>
+        [EnumMember(Value = "all")]
+        All
+    }
+}

--- a/Alpaca.Markets/Interfaces/IAccountConfiguration.cs
+++ b/Alpaca.Markets/Interfaces/IAccountConfiguration.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace Alpaca.Markets
+{
+    /// <summary>
+    /// Encapsulates account configuration settings from Alpaca REST API.
+    /// </summary>
+    public interface IAccountConfiguration
+    {
+        /// <summary>
+        /// Gets or sets day trade margin call protection mode for account.
+        /// </summary>
+        DayTradeMarginCallProtection DayTradeMarginCallProtection { get; set; }
+
+        /// <summary>
+        /// Gets or sets notification level for order fill emails.
+        /// </summary>
+        TradeConfirmEmail TradeConfirmEmail { get; set; }
+
+        /// <summary>
+        /// Gets or sets control flag for blocking new orders placement.
+        /// </summary>
+        Boolean IsSuspendTrade { get; set; }
+
+        /// <summary>
+        /// Gets or sets control flag for enabling long-only account mode.
+        /// </summary>
+        Boolean IsNoShorting { get; set; }
+    }
+}

--- a/Alpaca.Markets/Messages/JsonAccountConfiguration.cs
+++ b/Alpaca.Markets/Messages/JsonAccountConfiguration.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Alpaca.Markets
+{
+    [SuppressMessage(
+        "Microsoft.Performance", "CA1812:Avoid uninstantiated internal classes",
+        Justification = "Object instances of this class will be created by Newtonsoft.JSON library.")]
+    internal sealed class JsonAccountConfiguration : IAccountConfiguration
+    {
+        [JsonProperty(PropertyName = "dtbp_check", Required = Required.Always)]
+        public DayTradeMarginCallProtection DayTradeMarginCallProtection { get; set; }
+
+        [JsonProperty(PropertyName = "trade_confirm_email", Required = Required.Always)]
+        public TradeConfirmEmail TradeConfirmEmail { get; set; }
+
+        [JsonProperty(PropertyName = "suspend_trade", Required = Required.Always)]
+        public Boolean IsSuspendTrade { get; set; }
+
+        [JsonProperty(PropertyName = "no_shorting", Required = Required.Always)]
+        public Boolean IsNoShorting { get; set; }
+    }
+}

--- a/Alpaca.Markets/RestClient.General.cs
+++ b/Alpaca.Markets/RestClient.General.cs
@@ -29,6 +29,54 @@ namespace Alpaca.Markets
         }
 
         /// <summary>
+        /// Gets account configuration settings from Alpaca REST API endpoint.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Mutable version of account configuration object.</returns>
+        public Task<IAccountConfiguration> GetAccountConfigurationAsync(
+            CancellationToken cancellationToken = default)
+        {
+            var builder = new UriBuilder(_alpacaHttpClient.BaseAddress)
+            {
+                Path = _alpacaHttpClient.BaseAddress.AbsolutePath + "account/configurations",
+            };
+
+            return getSingleObjectAsync<IAccountConfiguration, JsonAccountConfiguration>(
+                _alpacaHttpClient, _alpacaRestApiThrottler, builder, cancellationToken);
+        }
+
+        /// <summary>
+        /// Updates account configuration settings using Alpaca REST API endpoint.
+        /// </summary>
+        /// <param name="accountConfiguration">New account configuration object for updating.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Mutable version of updated account configuration object.</returns>
+        public async Task<IAccountConfiguration> PatchAccountConfigurationAsync(
+            IAccountConfiguration accountConfiguration,
+            CancellationToken cancellationToken = default)
+        {
+            await _alpacaRestApiThrottler.WaitToProceed(cancellationToken).ConfigureAwait(false);
+
+            using (var request = new HttpRequestMessage(_httpMethodPatch,
+                new Uri("account/configurations", UriKind.RelativeOrAbsolute)))
+            {
+                var serializer = new JsonSerializer();
+                using (var stringWriter = new StringWriter())
+                {
+                    serializer.Serialize(stringWriter, accountConfiguration);
+                    request.Content = new StringContent(stringWriter.ToString());
+                }
+
+                using (var response = await _alpacaHttpClient.SendAsync(request, cancellationToken)
+                    .ConfigureAwait(false))
+                {
+                    return await deserializeAsync<IAccountConfiguration, JsonAccountConfiguration>(response)
+                        .ConfigureAwait(false);
+                }
+            }
+        }
+
+        /// <summary>
         /// Gets list of available assets from Alpaca REST API endpoint.
         /// </summary>
         /// <param name="assetStatus">Asset status for filtering.</param>

--- a/Alpaca.Markets/RestClient.cs
+++ b/Alpaca.Markets/RestClient.cs
@@ -22,6 +22,9 @@ namespace Alpaca.Markets
 
         private const Int32 DEFAULT_DATA_API_VERSION_NUMBER = 1;
 
+        // TODO: olegra - use built-in HttpMethod.Patch property in .NET Standard 2.1
+        private static readonly HttpMethod _httpMethodPatch = new HttpMethod("PATCH");
+
         private static readonly HashSet<Int32> _supportedApiVersions = new HashSet<Int32> { 1, 2 };
 
         private static readonly HashSet<Int32> _supportedDataApiVersions = new HashSet<Int32> { 1 };


### PR DESCRIPTION
Add new mutable interface `IAccountCofiguration` and corresponding class for proper JSON (de) serialization of this interface into SDK. Add two new methods `GetAccountConfigurationAsync` and `PatchAccountConfigurationAsync` into `RestClient` class for reading and updating account configuration settings.