### PR TITLE
Add support for new account activities endpoint

### DIFF
--- a/Alpaca.Markets/Enums/AccountActivityType.cs
+++ b/Alpaca.Markets/Enums/AccountActivityType.cs
@@ -1,0 +1,193 @@
+﻿using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Alpaca.Markets
+{
+    /// <summary>
+    /// Types of account activities
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum AccountActivityType
+    {
+        /// <summary>
+        /// Order fills (both partial and full fills)
+        /// </summary>
+        [EnumMember(Value = "FILL")]
+        Fill,
+
+        /// <summary>
+        /// Cash transactions (both CSD and CSR)
+        /// </summary>
+        [EnumMember(Value = "TRANS")]
+        Transaction,
+
+        /// <summary>
+        /// Miscellaneous or rarely used activity types (All types except those in TRANS, DIV, or FILL)
+        /// </summary>
+        [EnumMember(Value = "MISC")]
+        Miscellaneous,
+
+        /// <summary>
+        /// ACATS IN/OUT (Cash)
+        /// </summary>
+        [EnumMember(Value = "ACATC")]
+        ACATCash,
+
+        /// <summary>
+        /// ACATS IN/OUT (Securities)
+        /// </summary>
+        [EnumMember(Value = "ACATS")]
+        ACATSecurities,
+
+        /// <summary>
+        /// Cash disbursement(+)
+        /// </summary>
+        [EnumMember(Value = "CSD")]
+        CashDisbursement,
+
+        /// <summary>
+        /// Cash receipt(-)
+        /// </summary>
+        [EnumMember(Value = "CSR")]
+        CashReceipt,
+
+        /// <summary>
+        /// Dividends
+        /// </summary>
+        [EnumMember(Value = "DIV")]
+        Dividend,
+
+        /// <summary>
+        /// Dividend (capital gains long term)
+        /// </summary>
+        [EnumMember(Value = "DIVCGL")]
+        DividendCapitalGainsLongTerm,
+
+        /// <summary>
+        /// Dividend (capital gain short term)
+        /// </summary>
+        [EnumMember(Value = "DIVCGS")]
+        DividendCapitalGainsShortTerm,
+
+        /// <summary>
+        /// Dividend fee
+        /// </summary>
+        [EnumMember(Value = "DIVFEE")]
+        DividendFee,
+
+        /// <summary>
+        /// Dividend adjusted (Foreign Tax Withheld)
+        /// </summary>
+        [EnumMember(Value = "DIVFT")]
+        DividendForeignTaxWithheld,
+
+        /// <summary>
+        /// Dividend adjusted (NRA Withheld)
+        /// </summary>
+        [EnumMember(Value = "DIVNRA")]
+        DividendNRAWithheld,
+
+        /// <summary>
+        /// Dividend return of capital
+        /// </summary>
+        [EnumMember(Value = "DIVROC")]
+        DividendReturnOfCapital,
+
+        /// <summary>
+        /// Dividend adjusted (Tefra Withheld)
+        /// </summary>
+        [EnumMember(Value = "DIVTW")]
+        DividendTefraWithheld,
+
+        /// <summary>
+        /// Dividend (tax exempt)
+        /// </summary>
+        [EnumMember(Value = "DIVTXEX")]
+        DividendTaxExempt,
+
+        /// <summary>
+        /// Interest (credit/margin)
+        /// </summary>
+        [EnumMember(Value = "INT")]
+        Interest,
+
+        /// <summary>
+        /// Interest adjusted (NRA Withheld)
+        /// </summary>
+        [EnumMember(Value = "INTNRA")]
+        InterestNRAWithheld,
+
+        /// <summary>
+        /// Interest adjusted (Tefra Withheld)
+        /// </summary>
+        [EnumMember(Value = "INTTW")]
+        InterestTefraWithheld,
+
+        /// <summary>
+        /// Journal entry
+        /// </summary>
+        [EnumMember(Value = "JNL")]
+        JournalEntry,
+
+        /// <summary>
+        /// Journal entry (cash)
+        /// </summary>
+        [EnumMember(Value = "JNLC")]
+        JournalEntryCash,
+
+        /// <summary>
+        /// Journal entry (stock)
+        /// </summary>
+        [EnumMember(Value = "JNLS")]
+        JournalEntryStock,
+
+        /// <summary>
+        /// Merger/Acquisition
+        /// </summary>
+        [EnumMember(Value = "MA")]
+        MergerAcquisition,
+
+        /// <summary>
+        /// Name change
+        /// </summary>
+        [EnumMember(Value = "NC")]
+        NameChange,
+
+        /// <summary>
+        /// Pass Thru Charge
+        /// </summary>
+        [EnumMember(Value = "PTC")]
+        PassThruCharge,
+
+        /// <summary>
+        /// Pass Thru Rebate
+        /// </summary>
+        [EnumMember(Value = "PTR")]
+        PassThruRebate,
+
+        /// <summary>
+        /// Reorganization
+        /// </summary>
+        [EnumMember(Value = "REORG")]
+        Reorg,
+
+        /// <summary>
+        /// Symbol change
+        /// </summary>
+        [EnumMember(Value = "SC")]
+        SymbolChange,
+
+        /// <summary>
+        /// Stock spinoff
+        /// </summary>
+        [EnumMember(Value = "SSO")]
+        StockSpinoff,
+
+        /// <summary>
+        /// Stock split
+        /// </summary>
+        [EnumMember(Value = "SSP")]
+        StockSplit,
+    }
+}

--- a/Alpaca.Markets/Enums/OrderListSorting.cs
+++ b/Alpaca.Markets/Enums/OrderListSorting.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Alpaca.Markets
+{
+    /// <summary>
+    /// Order statuses sorting direction for old <see cref="RestClient.ListOrdersAsync"/> call from Alpaca REST API.
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    [Obsolete("Use SortDirection enum instead of this one.", false)]
+    public enum OrderListSorting
+    {
+        /// <summary>
+        /// Descending sort order
+        /// </summary>
+        [EnumMember(Value = "desc")]
+        Descending,
+
+        /// <summary>
+        /// Ascending sort order
+        /// </summary>
+        [EnumMember(Value = "asc")]
+        Ascending,
+    }
+}

--- a/Alpaca.Markets/Enums/SortDirection.cs
+++ b/Alpaca.Markets/Enums/SortDirection.cs
@@ -5,21 +5,21 @@ using Newtonsoft.Json.Converters;
 namespace Alpaca.Markets
 {
     /// <summary>
-    /// Order statuses sorting direction for <see cref="RestClient.ListOrdersAsync"/> call from Alpaca REST API.
+    /// Supported sort directions in Alpaca REST API.
     /// </summary>
     [JsonConverter(typeof(StringEnumConverter))]
-    public enum OrderListSorting
+    public enum SortDirection
     {
         /// <summary>
-        /// Returns only open orders.
+        /// Descending sort order
         /// </summary>
         [EnumMember(Value = "desc")]
         Descending,
 
         /// <summary>
-        /// Returns only closed orders.
+        /// Ascending sort order
         /// </summary>
         [EnumMember(Value = "asc")]
-        Ascending
+        Ascending,
     }
 }

--- a/Alpaca.Markets/Interfaces/IAccountActivity.cs
+++ b/Alpaca.Markets/Interfaces/IAccountActivity.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Alpaca.Markets
+{
+    /// <summary>
+    /// Encapsulates account activity information from Alpaca REST API.
+    /// </summary>
+    public interface IAccountActivity
+    {
+        /// <summary>
+        /// Activity type.
+        /// </summary>
+        AccountActivityType ActivityType { get; }
+
+        /// <summary>
+        /// An ID for the activity, always in "{date}::{uuid}" format. Can be sent as page_token in requests to facilitate the paging of results.
+        /// </summary>
+        String ActivityId { get; }
+
+        /// <summary>
+        /// The symbol of the security involved with the activity. Not present for all activity types.
+        /// </summary>
+        String Symbol { get; }
+
+        /// <summary>
+        /// The date on which the activity occurred or on which the transaction associated with the activity settled.
+        /// </summary>
+        DateTime? ActivityDate { get; }
+
+        /// <summary>
+        /// The net amount of money (positive or negative) associated with the activity.
+        /// </summary>
+        Decimal? NetAmount { get; }
+
+        /// <summary>
+        /// The number of shares that contributed to the transaction. Not present for all activity types.
+        /// </summary>
+        Int64? Quantity { get; }
+
+        /// <summary>
+        /// For dividend activities, the average amount paid per share. Not present for other activity types.
+        /// </summary>
+        Decimal? PerShareAmount { get; }
+
+        /// <summary>
+        /// The cumulative quantity of shares involved in the execution.
+        /// </summary>
+        Int64? CumulativeQuantity { get; }
+
+        /// <summary>
+        /// For partially_filled orders, the quantity of shares that are left to be filled.
+        /// </summary>
+        Int64? LeavesQuantity { get; }
+
+        /// <summary>
+        /// The per-share price that a trade was executed at.
+        /// </summary>
+        Decimal? Price { get; }
+
+        /// <summary>
+        /// The order side of a trade execution.
+        /// </summary>
+        OrderSide? Side { get; }
+
+        /// <summary>
+        /// The time at which an execution occurred.
+        /// </summary>
+        DateTime? TransactionTime { get; }
+
+        /// <summary>
+        /// The type of trade event associated with an execution.
+        /// </summary>
+        TradeEvent? Type { get; }
+    }
+}

--- a/Alpaca.Markets/Messages/JsonAccountActivity.cs
+++ b/Alpaca.Markets/Messages/JsonAccountActivity.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Alpaca.Markets
+{
+    [SuppressMessage(
+        "Microsoft.Performance", "CA1812:Avoid uninstantiated internal classes",
+        Justification = "Object instances of this class will be created by Newtonsoft.JSON library.")]
+    internal sealed class JsonAccountActivity : IAccountActivity
+    {
+
+
+        [JsonProperty(PropertyName = "activity_type", Required = Required.Always)]
+        public AccountActivityType ActivityType { get; set; }
+
+        [JsonProperty(PropertyName = "id", Required = Required.Always)]
+        public String ActivityId { get; set; }
+
+        [JsonProperty(PropertyName = "symbol", Required = Required.Default)]
+        public String Symbol { get; set; }
+
+        [JsonProperty(PropertyName = "date", Required = Required.Default)]
+        public DateTime? ActivityDate { get; set; }
+
+        [JsonProperty(PropertyName = "net_amount", Required = Required.Default)]
+        public Decimal? NetAmount { get; set; }
+
+        [JsonProperty(PropertyName = "qty", Required = Required.Default)]
+        public Int64? Quantity { get; set; }
+
+        [JsonProperty(PropertyName = "per_share_amount", Required = Required.Default)]
+        public Decimal? PerShareAmount { get; set; }
+
+        [JsonProperty(PropertyName = "cum_qty", Required = Required.Default)]
+        public Int64? CumulativeQuantity { get; set; }
+
+        [JsonProperty(PropertyName = "leaves_qty", Required = Required.Default)]
+        public Int64? LeavesQuantity { get; set; }
+
+        [JsonProperty(PropertyName = "price", Required = Required.Default)]
+        public Decimal? Price { get; set; }
+
+        [JsonProperty(PropertyName = "side", Required = Required.Default)]
+        public OrderSide? Side { get; set; }
+
+        [JsonProperty(PropertyName = "transaction_time", Required = Required.Default)]
+        public DateTime? TransactionTime { get; set; }
+
+        [JsonProperty(PropertyName = "type", Required = Required.Default)]
+        public TradeEvent? Type { get; set; }
+    }
+}

--- a/Alpaca.Markets/RestClient.General.cs
+++ b/Alpaca.Markets/RestClient.General.cs
@@ -98,6 +98,11 @@ namespace Alpaca.Markets
             String pageToken = null,
             CancellationToken cancellationToken = default)
         {
+            if (date.HasValue && (until.HasValue || after.HasValue))
+            {
+                throw new ArgumentException("You unable to specify 'date' and 'until'/'after' arguments in same call.");
+            }
+
             var builder = new UriBuilder(_alpacaHttpClient.BaseAddress)
             {
                 Path = _alpacaHttpClient.BaseAddress.AbsolutePath + "account/activities",

--- a/Alpaca.Markets/RestClient.General.cs
+++ b/Alpaca.Markets/RestClient.General.cs
@@ -77,6 +77,45 @@ namespace Alpaca.Markets
         }
 
         /// <summary>
+        /// Gets list of account activities from Alpaca REST API endpoint.
+        /// </summary>
+        /// <param name="activityTypes">The activity type you want to view entries for.</param>
+        /// <param name="date">The date for which you want to see activities.</param>
+        /// <param name="until">The response will contain only activities submitted before this date. (Cannot be used with date.)</param>
+        /// <param name="after">The response will contain only activities submitted after this date. (Cannot be used with date.)</param>
+        /// <param name="direction">The response will be sorted by time in this direction. (Default behavior is descending.)</param>
+        /// <param name="pageSize">The maximum number of entries to return in the response.</param>
+        /// <param name="pageToken">The ID of the end of your current page of results.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Read-only list of asset information objects.</returns>
+        public Task<IReadOnlyList<IAsset>> ListAccountActivitiesAsync(
+            IEnumerable<AccountActivityType> activityTypes = null,
+            DateTime? date = null,
+            DateTime? until = null,
+            DateTime? after = null,
+            SortDirection? direction = null,
+            Int64? pageSize = null,
+            String pageToken = null,
+            CancellationToken cancellationToken = default)
+        {
+            var builder = new UriBuilder(_alpacaHttpClient.BaseAddress)
+            {
+                Path = _alpacaHttpClient.BaseAddress.AbsolutePath + "account/activities",
+                Query = new QueryBuilder()
+                    .AddParameter("activity_types", string.Join(",", activityTypes))
+                    .AddParameter("date", date)
+                    .AddParameter("until", until)
+                    .AddParameter("after", after)
+                    .AddParameter("direction", direction)
+                    .AddParameter("pageSize", pageSize)
+                    .AddParameter("pageToken", pageToken)
+            };
+
+            return getObjectsListAsync<IAsset, JsonAsset>(
+                _alpacaHttpClient, _alpacaRestApiThrottler, builder, cancellationToken);
+        }
+
+        /// <summary>
         /// Gets list of available assets from Alpaca REST API endpoint.
         /// </summary>
         /// <param name="assetStatus">Asset status for filtering.</param>
@@ -131,7 +170,7 @@ namespace Alpaca.Markets
         /// <returns>Read-only list of order information objects.</returns>
         public Task<IReadOnlyList<IOrder>> ListOrdersAsync(
             OrderStatusFilter? orderStatusFilter = null,
-            OrderListSorting? orderListSorting = null,
+            SortDirection? orderListSorting = null,
             DateTime? untilDateTimeExclusive = null,
             DateTime? afterDateTimeExclusive = null,
             Int64? limitOrderNumber = null,


### PR DESCRIPTION
We've just recently added a new account activities endpoint: https://docs.alpaca.markets/api-documentation/api-v2/account-activities/

I've added almost all the activity types to an enum, leaving out only the options-related ones to avoid confusion. In the future, we might trim the list down a bit more, but for now all activity types are supported as parameters.