### PR TITLE
Fixing client instantiation in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 2. Add a reference for Alpaca .NET SDK with `dotnet add package Alpaca.Markets`.
 3. Change `Main` method in auto-generated `Programm.cs` file to this code snippet:
 ```cs
-var client = new Alpaca.Markets.Environments.Paper
+var client = Alpaca.Markets.Environments.Paper
     .GetAlpacaTradingClient(KEY_ID, new SecretKey(SECRET_KEY));
 
 var clock = client.GetClockAsync().Result;


### PR DESCRIPTION
new is not required to instantiate the client, just need to call `Environment.Paper.GetAlpacaTradingClient`