### PR TITLE
Update PolygonDataClient.cs

### DIFF
--- a/Alpaca.Markets/PolygonDataClient.cs
+++ b/Alpaca.Markets/PolygonDataClient.cs
@@ -250,7 +250,38 @@ namespace Alpaca.Markets
                 <IHistoricalItems<IAgg>, JsonHistoricalItems<IAgg, JsonMinuteAgg>>(
                     FakeThrottler.Instance, builder, cancellationToken);
         }
+         /// <summary>
+        /// Gets list of historical hour bars for single asset from Polygon's v2 REST API endpoint.
+        /// </summary>
+        /// <param name="symbol">>Asset name for data retrieval.</param>
+        /// <param name="multiplier">>Number of bars to combine in each result.</param>
+        /// <param name="dateFromInclusive">Start time for filtering (inclusive).</param>
+        /// <param name="dateToInclusive">End time for filtering (inclusive).</param>
+        /// <param name="unadjusted">Set to true if the results should not be adjusted for splits.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Read-only list of minute bars for specified asset.</returns>
+        public Task<IHistoricalItems<IAgg>> ListHourlyAggregatesAsync(
+            String symbol,
+            Int32 multiplier,
+            DateTime dateFromInclusive,
+            DateTime dateToInclusive,
+            Boolean unadjusted = false,
+            CancellationToken cancellationToken = default)
+        {
+            var unixFrom = DateTimeHelper.GetUnixTimeMilliseconds(dateFromInclusive);
+            var unixTo = DateTimeHelper.GetUnixTimeMilliseconds(dateToInclusive);
 
+            var builder = new UriBuilder(_httpClient.BaseAddress)
+            {
+                Path = $"v2/aggs/ticker/{symbol}/range/{multiplier}/hour/{unixFrom}/{unixTo}",
+                Query = getDefaultPolygonApiQueryBuilder()
+                    .AddParameter("unadjusted", unadjusted ? Boolean.TrueString : Boolean.FalseString)
+            };
+
+            return _httpClient.GetSingleObjectAsync
+                <IHistoricalItems<IAgg>, JsonHistoricalItems<IAgg, JsonMinuteAgg>>(
+                    FakeThrottler.Instance, builder, cancellationToken);
+        }
         /// <summary>
         /// Gets list of historical minute bars for single asset from Polygon's v2 REST API endpoint.
         /// </summary>


### PR DESCRIPTION
I was hoping to receive hourly candle data from Polygon and I noticed on their api doc it was a simple chage. Would you mind if added a new  public task ListHourlyAggregatesAsync with the path containing "hour". This way users can pull minute, hour, and daily candle information from Polygon?