### PR TITLE
Add OAuth authentication for Alpaca streaming connections

### DIFF
--- a/Alpaca.Markets/AlpacaDataClient.cs
+++ b/Alpaca.Markets/AlpacaDataClient.cs
@@ -26,8 +26,7 @@ namespace Alpaca.Markets
                 .EnsureNotNull(nameof(configuration))
                 .EnsureIsValid();
 
-            configuration.SecurityId
-                .AddAuthenticationHeader(_httpClient, configuration.KeyId);
+            _httpClient.AddAuthenticationHeaders(configuration.SecurityId);
 
             _httpClient.DefaultRequestHeaders.Accept
                 .Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/Alpaca.Markets/AlpacaStreamingClient.cs
+++ b/Alpaca.Markets/AlpacaStreamingClient.cs
@@ -53,25 +53,11 @@ namespace Alpaca.Markets
         /// <inheritdoc/>
         protected override void OnOpened()
         {
-            JsonAuthRequest.JsonData data;
-            if (String.IsNullOrEmpty(Configuration.OAuthToken))
-            {
-                data = new JsonAuthRequest.JsonData
-                {
-                    KeyId = Configuration.KeyId,
-                    SecretKey = Configuration.SecretKey
-                };
-            } else
-            {
-                data = new JsonAuthRequest.JsonData
-                {
-                    OAuthToken = Configuration.OAuthToken
-                };
-            }
             SendAsJsonString(new JsonAuthRequest
             {
                 Action = JsonAction.Authenticate,
-                Data = data
+                Data = Configuration.SecurityId
+                    .GetAuthenticationData()
             });
 
             base.OnOpened();

--- a/Alpaca.Markets/AlpacaStreamingClient.cs
+++ b/Alpaca.Markets/AlpacaStreamingClient.cs
@@ -53,14 +53,25 @@ namespace Alpaca.Markets
         /// <inheritdoc/>
         protected override void OnOpened()
         {
-            SendAsJsonString(new JsonAuthRequest
+            JsonAuthRequest.JsonData data;
+            if (String.IsNullOrEmpty(Configuration.OAuthToken))
             {
-                Action = JsonAction.Authenticate,
-                Data = new JsonAuthRequest.JsonData
+                data = new JsonAuthRequest.JsonData
                 {
                     KeyId = Configuration.KeyId,
                     SecretKey = Configuration.SecretKey
-                }
+                };
+            } else
+            {
+                data = new JsonAuthRequest.JsonData
+                {
+                    OAuthToken = Configuration.OAuthToken
+                };
+            }
+            SendAsJsonString(new JsonAuthRequest
+            {
+                Action = JsonAction.Authenticate,
+                Data = data
             });
 
             base.OnOpened();

--- a/Alpaca.Markets/AlpacaTradingClient.cs
+++ b/Alpaca.Markets/AlpacaTradingClient.cs
@@ -31,8 +31,7 @@ namespace Alpaca.Markets
 
             _alpacaRestApiThrottler = configuration.ThrottleParameters.GetThrottler();
 
-            configuration.SecurityId
-                .AddAuthenticationHeader(_httpClient, configuration.KeyId);
+            _httpClient.AddAuthenticationHeaders(configuration.SecurityId);
 
             _httpClient.DefaultRequestHeaders.Accept
                 .Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/Alpaca.Markets/Authentication/OAuthKey.cs
+++ b/Alpaca.Markets/Authentication/OAuthKey.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Net.Http;
+using System.Collections.Generic;
 
 namespace Alpaca.Markets
 {
@@ -12,14 +12,22 @@ namespace Alpaca.Markets
         /// Creates new instance of <see cref="OAuthKey"/> object.
         /// </summary>
         /// <param name="value">OAuth key.</param>
-        public OAuthKey(String value) : base(value) {}
-
-        internal override void AddAuthenticationHeader(
-            HttpClient httpClient,
-            String keyId)
+        public OAuthKey(
+            String value)
+            : base(value)
         {
-            httpClient.DefaultRequestHeaders.Add(
+        }
+
+        internal override IEnumerable<KeyValuePair<String, String>> GetAuthenticationHeaders()
+        {
+            yield return new KeyValuePair<String, String>(
                 "Authorization", "Bearer " + Value);
         }
+
+        internal override JsonAuthRequest.JsonData GetAuthenticationData() =>
+            new JsonAuthRequest.JsonData
+            {
+                OAuthToken = Value
+            };
     }
 }

--- a/Alpaca.Markets/Authentication/SecretKey.cs
+++ b/Alpaca.Markets/Authentication/SecretKey.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net.Http;
 
 namespace Alpaca.Markets
@@ -11,17 +12,29 @@ namespace Alpaca.Markets
         /// <summary>
         /// Creates new instance of <see cref="SecretKey"/> object.
         /// </summary>
+        /// <param name="keyId">Secret API key identifier.</param>
         /// <param name="value">Secret API key value.</param>
-        public SecretKey(String value) : base(value) {}
+        public SecretKey(
+            String keyId,
+            String value)
+            : base(value) =>
+            KeyId = keyId;
 
-        internal override void AddAuthenticationHeader(
-            HttpClient httpClient,
-            String keyId)
+        internal String KeyId { get; }
+
+        internal override IEnumerable<KeyValuePair<String, String>> GetAuthenticationHeaders()
         {
-            httpClient.DefaultRequestHeaders.Add(
-                "APCA-API-KEY-ID", keyId);
-            httpClient.DefaultRequestHeaders.Add(
+            yield return new KeyValuePair<String, String>(
+                "APCA-API-KEY-ID", KeyId);
+            yield return new KeyValuePair<String, String>(
                 "APCA-API-SECRET-KEY", Value);
         }
+
+        internal override JsonAuthRequest.JsonData GetAuthenticationData() =>
+            new JsonAuthRequest.JsonData
+            {
+                KeyId = KeyId,
+                SecretKey = Value
+            };
     }
 }

--- a/Alpaca.Markets/Authentication/SecurityKey.cs
+++ b/Alpaca.Markets/Authentication/SecurityKey.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Net.Http;
+using System.Collections.Generic;
 
 namespace Alpaca.Markets
 {
@@ -17,15 +17,8 @@ namespace Alpaca.Markets
 
         internal String Value { get; }
 
-        internal abstract void AddAuthenticationHeader(
-            HttpClient httpClient,
-            String keyId);
+        internal abstract IEnumerable<KeyValuePair<String, String>> GetAuthenticationHeaders();
 
-        internal static SecurityKey Create(
-            String secretKey,
-            String oauthKey) => 
-            String.IsNullOrEmpty(secretKey)
-                ? (SecurityKey) new SecretKey(secretKey)
-                : new OAuthKey(oauthKey);
+        internal abstract JsonAuthRequest.JsonData GetAuthenticationData();
     }
 }

--- a/Alpaca.Markets/Environment/EnvironmentExtensions.cs
+++ b/Alpaca.Markets/Environment/EnvironmentExtensions.cs
@@ -110,12 +110,14 @@ namespace Alpaca.Markets
         /// <param name="environment">Target environment for new object.</param>
         /// <param name="keyId">Alpaca API key identifier.</param>
         /// <param name="secretKey">Alpaca API secret key.</param>
+        /// <param name="oauthToken">Alpaca API oauth token. If provided, key and secret key will be ignored.</param>
         /// <returns>New instance of <see cref="AlpacaStreamingClient"/> object.</returns>
         public static AlpacaStreamingClient GetAlpacaStreamingClient(
             this IEnvironment environment,
             String keyId,
-            String secretKey) =>
-            new AlpacaStreamingClient(environment.GetAlpacaStreamingClientConfiguration(keyId, secretKey));
+            String secretKey,
+            String? oauthToken) =>
+            new AlpacaStreamingClient(environment.GetAlpacaStreamingClientConfiguration(keyId, secretKey, oauthToken));
 
         /// <summary>
         /// Creates new instance of <see cref="AlpacaStreamingClientConfiguration"/> for specific
@@ -124,16 +126,19 @@ namespace Alpaca.Markets
         /// <param name="environment">Target environment for new object.</param>
         /// <param name="keyId">Alpaca API key identifier.</param>
         /// <param name="secretKey">Alpaca API secret key.</param>
+        /// <param name="oauthToken">Alpaca API oauth token. If provided, key and secret key will be ignored.</param>
         /// <returns>New instance of <see cref="AlpacaStreamingClientConfiguration"/> object.</returns>
         public static AlpacaStreamingClientConfiguration GetAlpacaStreamingClientConfiguration(
             this IEnvironment environment,
             String keyId,
-            String secretKey) =>
+            String secretKey,
+            String? oauthToken) =>
             new AlpacaStreamingClientConfiguration()
             {
                 ApiEndpoint = environment?.AlpacaStreamingApi ?? throw new ArgumentNullException(nameof(environment)),
-                SecretKey = secretKey ?? throw new ArgumentNullException(nameof(secretKey)),
-                KeyId = keyId ?? throw new ArgumentNullException(nameof(keyId))
+                SecretKey = secretKey ?? oauthToken ?? throw new ArgumentNullException(nameof(secretKey)),
+                KeyId = keyId ?? oauthToken ?? throw new ArgumentNullException(nameof(keyId)),
+                OAuthToken = oauthToken ?? String.Empty
             };
 
         /// <summary>

--- a/Alpaca.Markets/Environment/EnvironmentExtensions.cs
+++ b/Alpaca.Markets/Environment/EnvironmentExtensions.cs
@@ -114,9 +114,9 @@ namespace Alpaca.Markets
         /// <returns>New instance of <see cref="AlpacaStreamingClient"/> object.</returns>
         public static AlpacaStreamingClient GetAlpacaStreamingClient(
             this IEnvironment environment,
-            String keyId,
-            String secretKey,
-            String? oauthToken) =>
+            String? keyId = null,
+            String? secretKey = null,
+            String? oauthToken = null) =>
             new AlpacaStreamingClient(environment.GetAlpacaStreamingClientConfiguration(keyId, secretKey, oauthToken));
 
         /// <summary>
@@ -130,9 +130,9 @@ namespace Alpaca.Markets
         /// <returns>New instance of <see cref="AlpacaStreamingClientConfiguration"/> object.</returns>
         public static AlpacaStreamingClientConfiguration GetAlpacaStreamingClientConfiguration(
             this IEnvironment environment,
-            String keyId,
-            String secretKey,
-            String? oauthToken) =>
+            String? keyId = null,
+            String? secretKey = null,
+            String? oauthToken = null) =>
             new AlpacaStreamingClientConfiguration()
             {
                 ApiEndpoint = environment?.AlpacaStreamingApi ?? throw new ArgumentNullException(nameof(environment)),

--- a/Alpaca.Markets/Environment/EnvironmentExtensions.cs
+++ b/Alpaca.Markets/Environment/EnvironmentExtensions.cs
@@ -14,32 +14,27 @@ namespace Alpaca.Markets
         /// environment provided as <paramref name="environment"/> argument.
         /// </summary>
         /// <param name="environment">Target environment for new object.</param>
-        /// <param name="keyId">Alpaca API key identifier.</param>
         /// <param name="securityKey">Alpaca API security key.</param>
         /// <returns>New instance of <see cref="AlpacaTradingClient"/> object.</returns>
         public static AlpacaTradingClient GetAlpacaTradingClient(
             this IEnvironment environment,
-            String keyId,
             SecurityKey securityKey) =>
-            new AlpacaTradingClient(environment.GetAlpacaTradingClientConfiguration(keyId, securityKey));
+            new AlpacaTradingClient(environment.GetAlpacaTradingClientConfiguration(securityKey));
 
         /// <summary>
         /// Creates new instance of <see cref="AlpacaTradingClientConfiguration"/> for specific
         /// environment provided as <paramref name="environment"/> argument.
         /// </summary>
         /// <param name="environment">Target environment for new object.</param>
-        /// <param name="keyId">Alpaca API key identifier.</param>
         /// <param name="securityKey">Alpaca API security key.</param>
         /// <returns>New instance of <see cref="AlpacaTradingClientConfiguration"/> object.</returns>
         public static AlpacaTradingClientConfiguration GetAlpacaTradingClientConfiguration(
             this IEnvironment environment,
-            String keyId,
             SecurityKey securityKey) =>
             new AlpacaTradingClientConfiguration
             {
                 ApiEndpoint = environment?.AlpacaTradingApi ?? throw new ArgumentNullException(nameof(environment)),
                 SecurityId = securityKey ?? throw new ArgumentNullException(nameof(securityKey)),
-                KeyId = keyId ?? throw new ArgumentNullException(nameof(keyId))
             };
 
         /// <summary>
@@ -47,32 +42,27 @@ namespace Alpaca.Markets
         /// environment provided as <paramref name="environment"/> argument.
         /// </summary>
         /// <param name="environment">Target environment for new object.</param>
-        /// <param name="keyId">Alpaca API key identifier.</param>
         /// <param name="securityKey">Alpaca API security key.</param>
         /// <returns>New instance of <see cref="AlpacaDataClient"/> object.</returns>
         public static AlpacaDataClient GetAlpacaDataClient(
             this IEnvironment environment,
-            String keyId,
             SecurityKey securityKey) =>
-            new AlpacaDataClient(environment.GetAlpacaDataClientConfiguration(keyId, securityKey));
+            new AlpacaDataClient(environment.GetAlpacaDataClientConfiguration(securityKey));
 
         /// <summary>
         /// Creates new instance of <see cref="AlpacaDataClientConfiguration"/> for specific
         /// environment provided as <paramref name="environment"/> argument.
         /// </summary>
         /// <param name="environment">Target environment for new object.</param>
-        /// <param name="keyId">Alpaca API key identifier.</param>
         /// <param name="securityKey">Alpaca API security key.</param>
         /// <returns>New instance of <see cref="AlpacaDataClientConfiguration"/> object.</returns>
         public static AlpacaDataClientConfiguration GetAlpacaDataClientConfiguration(
             this IEnvironment environment,
-            String keyId,
             SecurityKey securityKey) =>
             new AlpacaDataClientConfiguration
             {
                 ApiEndpoint = environment?.AlpacaDataApi ?? throw new ArgumentNullException(nameof(environment)),
                 SecurityId = securityKey ?? throw new ArgumentNullException(nameof(securityKey)),
-                KeyId = keyId ?? throw new ArgumentNullException(nameof(keyId))
             };
 
         /// <summary>
@@ -108,37 +98,27 @@ namespace Alpaca.Markets
         /// environment provided as <paramref name="environment"/> argument.
         /// </summary>
         /// <param name="environment">Target environment for new object.</param>
-        /// <param name="keyId">Alpaca API key identifier.</param>
-        /// <param name="secretKey">Alpaca API secret key.</param>
-        /// <param name="oauthToken">Alpaca API oauth token. If provided, key and secret key will be ignored.</param>
+        /// <param name="securityKey">Alpaca API security key.</param>
         /// <returns>New instance of <see cref="AlpacaStreamingClient"/> object.</returns>
         public static AlpacaStreamingClient GetAlpacaStreamingClient(
             this IEnvironment environment,
-            String? keyId = null,
-            String? secretKey = null,
-            String? oauthToken = null) =>
-            new AlpacaStreamingClient(environment.GetAlpacaStreamingClientConfiguration(keyId, secretKey, oauthToken));
+            SecurityKey securityKey) =>
+            new AlpacaStreamingClient(environment.GetAlpacaStreamingClientConfiguration(securityKey));
 
         /// <summary>
         /// Creates new instance of <see cref="AlpacaStreamingClientConfiguration"/> for specific
         /// environment provided as <paramref name="environment"/> argument.
         /// </summary>
         /// <param name="environment">Target environment for new object.</param>
-        /// <param name="keyId">Alpaca API key identifier.</param>
-        /// <param name="secretKey">Alpaca API secret key.</param>
-        /// <param name="oauthToken">Alpaca API oauth token. If provided, key and secret key will be ignored.</param>
+        /// <param name="securityKey">Alpaca API security key.</param>
         /// <returns>New instance of <see cref="AlpacaStreamingClientConfiguration"/> object.</returns>
         public static AlpacaStreamingClientConfiguration GetAlpacaStreamingClientConfiguration(
             this IEnvironment environment,
-            String? keyId = null,
-            String? secretKey = null,
-            String? oauthToken = null) =>
+            SecurityKey securityKey) =>
             new AlpacaStreamingClientConfiguration()
             {
                 ApiEndpoint = environment?.AlpacaStreamingApi ?? throw new ArgumentNullException(nameof(environment)),
-                SecretKey = secretKey ?? oauthToken ?? throw new ArgumentNullException(nameof(secretKey)),
-                KeyId = keyId ?? oauthToken ?? throw new ArgumentNullException(nameof(keyId)),
-                OAuthToken = oauthToken ?? String.Empty
+                SecurityId = securityKey,
             };
 
         /// <summary>

--- a/Alpaca.Markets/Helpers/HttpClientExtensions.cs
+++ b/Alpaca.Markets/Helpers/HttpClientExtensions.cs
@@ -11,6 +11,16 @@ namespace Alpaca.Markets
 {
     internal static class HttpClientExtensions
     {
+        public static void AddAuthenticationHeaders(
+            this HttpClient httpClient,
+            SecurityKey securityKey)
+        {
+            foreach (var pair in securityKey.GetAuthenticationHeaders())
+            {
+                httpClient.DefaultRequestHeaders.Add(pair.Key, pair.Value);
+            }
+        }
+
         public static Task<TApi> GetSingleObjectAsync<TApi, TJson>(
             this HttpClient httpClient,
             IThrottler throttler,

--- a/Alpaca.Markets/Messages/JsonAuthRequest.cs
+++ b/Alpaca.Markets/Messages/JsonAuthRequest.cs
@@ -7,11 +7,14 @@ namespace Alpaca.Markets
     {
         internal sealed class JsonData
         {
-            [JsonProperty(PropertyName = "key_id", Required = Required.Always)]
+            [JsonProperty(PropertyName = "key_id", Required = Required.Default)]
             public String KeyId { get; set; } = String.Empty;
 
-            [JsonProperty(PropertyName = "secret_key", Required = Required.Always)]
+            [JsonProperty(PropertyName = "secret_key", Required = Required.Default)]
             public String SecretKey { get; set; } = String.Empty;
+
+            [JsonProperty(PropertyName = "oauth_token", Required = Required.Default)]
+            public String OAuthToken { get; set; } = String.Empty;
         }
 
         [JsonProperty(PropertyName = "action", Required = Required.Always)]

--- a/Alpaca.Markets/Messages/JsonAuthRequest.cs
+++ b/Alpaca.Markets/Messages/JsonAuthRequest.cs
@@ -7,14 +7,14 @@ namespace Alpaca.Markets
     {
         internal sealed class JsonData
         {
-            [JsonProperty(PropertyName = "key_id", Required = Required.Default)]
-            public String KeyId { get; set; } = String.Empty;
+            [JsonProperty(PropertyName = "key_id", Required = Required.Default, NullValueHandling = NullValueHandling.Ignore)]
+            public String? KeyId { get; set; }
 
-            [JsonProperty(PropertyName = "secret_key", Required = Required.Default)]
-            public String SecretKey { get; set; } = String.Empty;
+            [JsonProperty(PropertyName = "secret_key", Required = Required.Default, NullValueHandling = NullValueHandling.Ignore)]
+            public String? SecretKey { get; set; }
 
-            [JsonProperty(PropertyName = "oauth_token", Required = Required.Default)]
-            public String OAuthToken { get; set; } = String.Empty;
+            [JsonProperty(PropertyName = "oauth_token", Required = Required.Default, NullValueHandling = NullValueHandling.Ignore)]
+            public String? OAuthToken { get; set; }
         }
 
         [JsonProperty(PropertyName = "action", Required = Required.Always)]

--- a/Alpaca.Markets/Messages/JsonAuthResponse.cs
+++ b/Alpaca.Markets/Messages/JsonAuthResponse.cs
@@ -14,5 +14,8 @@ namespace Alpaca.Markets
 
         [JsonProperty(PropertyName = "status", Required = Required.Always)]
         public AuthStatus Status { get; set; }
+
+        [JsonProperty(PropertyName = "message", Required = Required.Default)]
+        public String Message { get; set; } = String.Empty;
     }
 }

--- a/Alpaca.Markets/Obsolete/RestClient.cs
+++ b/Alpaca.Markets/Obsolete/RestClient.cs
@@ -115,7 +115,7 @@ namespace Alpaca.Markets
             return new RestClientConfiguration
             {
                 KeyId = keyId ?? throw new ArgumentException("Application key id should not be null.", nameof(keyId)),
-                SecurityId = SecurityKey.Create(secretKey, oauthKey),
+                SecurityId = String.IsNullOrEmpty(secretKey) ? (SecurityKey) new SecretKey(keyId, secretKey) : new OAuthKey(oauthKey),
                 TradingApiUrl = alpacaRestApi ?? Environments.Live.AlpacaTradingApi,
                 PolygonApiUrl = polygonRestApi ?? Environments.Live.PolygonDataApi,
                 DataApiUrl = alpacaDataApi ?? Environments.Live.AlpacaDataApi,

--- a/Alpaca.Markets/Obsolete/RestClientConfiguration.cs
+++ b/Alpaca.Markets/Obsolete/RestClientConfiguration.cs
@@ -13,7 +13,7 @@ namespace Alpaca.Markets
         public RestClientConfiguration()
         {
             KeyId = String.Empty;
-            SecurityId = new SecretKey(String.Empty);
+            SecurityId = new SecretKey(String.Empty, String.Empty);
 
             DataApiUrl = Environments.Live.AlpacaDataApi;
             TradingApiUrl = Environments.Live.AlpacaTradingApi;
@@ -70,14 +70,12 @@ namespace Alpaca.Markets
         internal AlpacaDataClientConfiguration AlpacaDataClientConfiguration =>
             new AlpacaDataClientConfiguration
             {
-                KeyId = KeyId,
                 ApiEndpoint = DataApiUrl
             };
 
         internal AlpacaTradingClientConfiguration AlpacaTradingClientConfiguration =>
             new AlpacaTradingClientConfiguration
             {
-                KeyId = KeyId,
                 SecurityId = SecurityId,
                 ApiEndpoint = TradingApiUrl
             };

--- a/Alpaca.Markets/Obsolete/SockClient.cs
+++ b/Alpaca.Markets/Obsolete/SockClient.cs
@@ -105,8 +105,9 @@ namespace Alpaca.Markets
             IWebSocketFactory? webSocketFactory) =>
             new AlpacaStreamingClientConfiguration
             {
-                KeyId = keyId ?? throw new ArgumentException("Application key id should not be null.", nameof(keyId)),
-                SecretKey = secretKey ?? throw new ArgumentException("Application secret key should not be null.", nameof(secretKey)),
+                SecurityId = new SecretKey(
+                    keyId ?? throw new ArgumentException("Application key id should not be null.", nameof(keyId)),
+                    secretKey ?? throw new ArgumentException("Application secret key should not be null.", nameof(secretKey))),
                 ApiEndpoint = alpacaRestApi ?? Environments.Live.AlpacaTradingApi,
                 WebSocketFactory = webSocketFactory ?? WebSocket4NetFactory.Instance,
             };

--- a/Alpaca.Markets/Parameters/AlpacaDataClientConfiguration.cs
+++ b/Alpaca.Markets/Parameters/AlpacaDataClientConfiguration.cs
@@ -17,16 +17,10 @@ namespace Alpaca.Markets
         /// </summary>
         public AlpacaDataClientConfiguration()
         {
-            KeyId = String.Empty;
             ApiVersion = DefaultApiVersion;
-            SecurityId = new SecretKey(String.Empty);
+            SecurityId = new SecretKey(String.Empty, String.Empty);
             ApiEndpoint = Environments.Live.AlpacaDataApi;
         }
-
-        /// <summary>
-        /// Gets or sets Alpaca application key identifier.
-        /// </summary>
-        public String KeyId { get; set; }
 
         /// <summary>
         /// Security identifier for API authentication.
@@ -45,12 +39,6 @@ namespace Alpaca.Markets
 
         internal void EnsureIsValid()
         {
-            if (String.IsNullOrEmpty(KeyId))
-            {
-                throw new InvalidOperationException(
-                    $"The value of '{nameof(KeyId)}' property shouldn't be null or empty.");
-            }
-
             if (ApiEndpoint == null)
             {
                 throw new InvalidOperationException(

--- a/Alpaca.Markets/Parameters/AlpacaStreamingClientConfiguration.cs
+++ b/Alpaca.Markets/Parameters/AlpacaStreamingClientConfiguration.cs
@@ -13,28 +13,22 @@ namespace Alpaca.Markets
         public AlpacaStreamingClientConfiguration()
             : base(Environments.Live.AlpacaStreamingApi)
         {
-            SecretKey = String.Empty;
-            OAuthToken = String.Empty;
+            SecurityId = new SecretKey(String.Empty, String.Empty);
         }
 
         /// <summary>
         /// Gets or sets Alpaca secret key identifier.
         /// </summary>
-        public String SecretKey { get; set; }
-
-        /// <summary>
-        /// Gets or sets Alpaca oauth token identifier.
-        /// </summary>
-        public String OAuthToken { get; set; }
+        public SecurityKey SecurityId { get; set; }
 
         internal override void EnsureIsValid()
         {
             base.EnsureIsValid();
 
-            if (String.IsNullOrEmpty(OAuthToken) && String.IsNullOrEmpty(SecretKey))
+            if (String.IsNullOrEmpty(SecurityId.Value))
             {
                 throw new InvalidOperationException(
-                    $"The value of '{nameof(SecretKey)}' property shouldn't be null or empty.");
+                    $"The value of '{nameof(SecurityId)}' property shouldn't be null or empty.");
             }
         }
     }

--- a/Alpaca.Markets/Parameters/AlpacaStreamingClientConfiguration.cs
+++ b/Alpaca.Markets/Parameters/AlpacaStreamingClientConfiguration.cs
@@ -14,6 +14,7 @@ namespace Alpaca.Markets
             : base(Environments.Live.AlpacaStreamingApi)
         {
             SecretKey = String.Empty;
+            OAuthToken = String.Empty;
         }
 
         /// <summary>
@@ -21,11 +22,16 @@ namespace Alpaca.Markets
         /// </summary>
         public String SecretKey { get; set; }
 
+        /// <summary>
+        /// Gets or sets Alpaca oauth token identifier.
+        /// </summary>
+        public String OAuthToken { get; set; }
+
         internal override void EnsureIsValid()
         {
             base.EnsureIsValid();
 
-            if (String.IsNullOrEmpty(SecretKey))
+            if (String.IsNullOrEmpty(OAuthToken) && String.IsNullOrEmpty(SecretKey))
             {
                 throw new InvalidOperationException(
                     $"The value of '{nameof(SecretKey)}' property shouldn't be null or empty.");

--- a/Alpaca.Markets/Parameters/AlpacaTradingClientConfiguration.cs
+++ b/Alpaca.Markets/Parameters/AlpacaTradingClientConfiguration.cs
@@ -17,17 +17,11 @@ namespace Alpaca.Markets
         /// </summary>
         public AlpacaTradingClientConfiguration()
         {
-            KeyId = String.Empty;
             ApiVersion = DefaultApiVersion;
-            SecurityId = new SecretKey(String.Empty);
+            SecurityId = new SecretKey(String.Empty, String.Empty);
             ApiEndpoint = Environments.Live.AlpacaTradingApi;
             ThrottleParameters = ThrottleParameters.Default;
         }
-
-        /// <summary>
-        /// Gets or sets Alpaca application key identifier.
-        /// </summary>
-        public String KeyId { get; set; }
 
         /// <summary>
         /// Security identifier for API authentication.
@@ -51,12 +45,6 @@ namespace Alpaca.Markets
 
         internal void EnsureIsValid()
         {
-            if (String.IsNullOrEmpty(KeyId))
-            {
-                throw new InvalidOperationException(
-                    $"The value of '{nameof(KeyId)}' property shouldn't be null or empty.");
-            }
-
             if (SecurityId == null)
             {
                 throw new InvalidOperationException(

--- a/Alpaca.Markets/Parameters/PolygonStreamingClientConfiguration.cs
+++ b/Alpaca.Markets/Parameters/PolygonStreamingClientConfiguration.cs
@@ -1,4 +1,6 @@
-﻿namespace Alpaca.Markets
+﻿using System;
+
+namespace Alpaca.Markets
 {
     /// <summary>
     /// Configuration parameters object for <see cref="PolygonStreamingClient"/> class.
@@ -11,6 +13,23 @@
         public PolygonStreamingClientConfiguration()
             : base(Environments.Live.PolygonStreamingApi)
         {
+            KeyId = String.Empty;
+        }
+
+        /// <summary>
+        /// Gets or sets Alpaca application key identifier.
+        /// </summary>
+        public String KeyId { get; set; }
+
+        internal override void EnsureIsValid()
+        {
+            base.EnsureIsValid();
+
+            if (String.IsNullOrEmpty(KeyId))
+            {
+                throw new InvalidOperationException(
+                    $"The value of '{nameof(KeyId)}' property shouldn't be null or empty.");
+            }
         }
     }
 }

--- a/Alpaca.Markets/Parameters/StreamingClientConfiguration.cs
+++ b/Alpaca.Markets/Parameters/StreamingClientConfiguration.cs
@@ -12,15 +12,9 @@ namespace Alpaca.Markets
         /// </summary>
         protected internal StreamingClientConfiguration(Uri apiEndpoint)
         {
-            KeyId = String.Empty;
             ApiEndpoint = apiEndpoint;
             WebSocketFactory = WebSocket4NetFactory.Instance;
         }
-
-        /// <summary>
-        /// Gets or sets Alpaca application key identifier.
-        /// </summary>
-        public String KeyId { get; set; }
 
         /// <summary>
         /// Gets or sets Alpaca streaming API base URL.
@@ -37,12 +31,6 @@ namespace Alpaca.Markets
 
         internal virtual void EnsureIsValid()
         {
-            if (String.IsNullOrEmpty(KeyId))
-            {
-                throw new InvalidOperationException(
-                    $"The value of '{nameof(KeyId)}' property shouldn't be null or empty.");
-            }
-
             if (ApiEndpoint == null)
             {
                 throw new InvalidOperationException(

--- a/UsageExamples/MeanReversionBrokerage.cs
+++ b/UsageExamples/MeanReversionBrokerage.cs
@@ -37,12 +37,12 @@ namespace UsageExamples
 
         public async Task Run()
         {
-            alpacaTradingClient = Environments.Paper.GetAlpacaTradingClient(API_KEY, new SecretKey(API_SECRET));
+            alpacaTradingClient = Environments.Paper.GetAlpacaTradingClient(new SecretKey(API_KEY, API_SECRET));
 
             polygonDataClient = Environments.Paper.GetPolygonDataClient(API_KEY);
 
             // Connect to Alpaca's websocket and listen for updates on our orders.
-            alpacaStreamingClient = Environments.Paper.GetAlpacaStreamingClient(API_KEY, API_SECRET);
+            alpacaStreamingClient = Environments.Paper.GetAlpacaStreamingClient(new SecretKey(API_KEY, API_SECRET));
 
             alpacaStreamingClient.ConnectAndAuthenticateAsync().Wait();
 

--- a/UsageExamples/MeanReversionPaperOnly.cs
+++ b/UsageExamples/MeanReversionPaperOnly.cs
@@ -28,9 +28,9 @@ namespace UsageExamples
 
         public async Task Run()
         {
-            alpacaTradingClient = Environments.Paper.GetAlpacaTradingClient(API_KEY, new SecretKey(API_SECRET));
+            alpacaTradingClient = Environments.Paper.GetAlpacaTradingClient(new SecretKey(API_KEY, API_SECRET));
 
-            alpacaDataClient = Environments.Paper.GetAlpacaDataClient(API_KEY, new SecretKey(API_SECRET));
+            alpacaDataClient = Environments.Paper.GetAlpacaDataClient(new SecretKey(API_KEY, API_SECRET));
 
             // First, cancel any existing orders so they don't impact our buying power.
             var orders = await alpacaTradingClient.ListOrdersAsync();


### PR DESCRIPTION
We had a request specifically for supporting Alpaca streaming connections via OAuth access tokens. In the future, we should also support them for REST connections, but the streaming connection should suffice for now.