### PR TITLE
Establish positive data types for volume and size

### DIFF
--- a/Alpaca.Markets/AlpacaDataClient.cs
+++ b/Alpaca.Markets/AlpacaDataClient.cs
@@ -39,6 +39,7 @@ namespace Alpaca.Markets
         public void Dispose() => _httpClient.Dispose();
 
         /// <inheritdoc />
+        [CLSCompliant(false)]
         public Task<IReadOnlyDictionary<String, IReadOnlyList<IAgg>>> GetBarSetAsync(
             BarSetRequest request,
             CancellationToken cancellationToken = default) =>
@@ -47,6 +48,7 @@ namespace Alpaca.Markets
                 StringComparer.Ordinal, cancellationToken);
 
         /// <inheritdoc />
+        [CLSCompliant(false)]
         public Task<ILastTrade> GetLastTradeAsync(
             String symbol,
             CancellationToken cancellationToken = default) =>
@@ -54,6 +56,7 @@ namespace Alpaca.Markets
                 $"v1/last/stocks/{symbol}", cancellationToken);
 
         /// <inheritdoc />
+        [CLSCompliant(false)]
         public Task<ILastQuote> GetLastQuoteAsync(
             String symbol,
             CancellationToken cancellationToken = default) =>
@@ -61,6 +64,7 @@ namespace Alpaca.Markets
                 $"v1/last_quote/stocks/{symbol}", cancellationToken);
 
         /// <inheritdoc />
+        [CLSCompliant(false)]
         public Task<IPage<IAgg>> ListHistoricalBarsAsync(
             HistoricalBarsRequest request,
             CancellationToken cancellationToken = default) =>
@@ -69,6 +73,7 @@ namespace Alpaca.Markets
                 cancellationToken);
 
         /// <inheritdoc />
+        [CLSCompliant(false)]
         public Task<IPage<IHistoricalQuote>> ListHistoricalQuotesAsync(
             HistoricalQuotesRequest request, 
             CancellationToken cancellationToken = default) =>
@@ -77,6 +82,7 @@ namespace Alpaca.Markets
                 cancellationToken);
 
         /// <inheritdoc />
+        [CLSCompliant(false)]
         public Task<IPage<IHistoricalTrade>> ListHistoricalTradesAsync(
             HistoricalTradesRequest request, 
             CancellationToken cancellationToken = default) =>

--- a/Alpaca.Markets/AlpacaDataStreamingClient.cs
+++ b/Alpaca.Markets/AlpacaDataStreamingClient.cs
@@ -121,20 +121,24 @@ namespace Alpaca.Markets
             };
 
         /// <inheritdoc />
+        [CLSCompliant(false)]
         public IAlpacaDataSubscription<IStreamTrade> GetTradeSubscription(
             String symbol) => 
             _subscriptions.GetOrAdd<IStreamTrade, JsonStreamTradeAlpaca>(getStreamName(TradesChannel, symbol));
 
         /// <inheritdoc />
+        [CLSCompliant(false)]
         public IAlpacaDataSubscription<IStreamQuote> GetQuoteSubscription(
             String symbol) =>
             _subscriptions.GetOrAdd<IStreamQuote, JsonStreamQuoteAlpaca>(getStreamName(QuotesChannel, symbol));
 
         /// <inheritdoc />
+        [CLSCompliant(false)]
         public IAlpacaDataSubscription<IStreamAgg> GetMinuteAggSubscription() => 
             _subscriptions.GetOrAdd<IStreamAgg, JsonStreamAggAlpaca>(getStreamName(BarsChannel, WildcardSymbolString));
 
         /// <inheritdoc />
+        [CLSCompliant(false)]
         public IAlpacaDataSubscription<IStreamAgg> GetMinuteAggSubscription(
             String symbol) =>
             _subscriptions.GetOrAdd<IStreamAgg, JsonStreamAggAlpaca>(getStreamName(BarsChannel, symbol));

--- a/Alpaca.Markets/AlpacaStreamingClient.cs
+++ b/Alpaca.Markets/AlpacaStreamingClient.cs
@@ -45,6 +45,7 @@ namespace Alpaca.Markets
         public event Action<IAccountUpdate>? OnAccountUpdate;
 
         /// <inheritdoc />
+        [CLSCompliant(false)]
         public event Action<ITradeUpdate>? OnTradeUpdate;
 
         /// <inheritdoc/>

--- a/Alpaca.Markets/AlpacaTradingClient.General.cs
+++ b/Alpaca.Markets/AlpacaTradingClient.General.cs
@@ -8,6 +8,7 @@ namespace Alpaca.Markets
     public sealed partial class AlpacaTradingClient
     {
         /// <inheritdoc />
+        [CLSCompliant(false)]
         public Task<IAccount> GetAccountAsync(
             CancellationToken cancellationToken = default) =>
             _httpClient.GetAsync<IAccount, JsonAccount>(
@@ -83,6 +84,7 @@ namespace Alpaca.Markets
                 request.EnsureNotNull(nameof(request)).GetUriBuilder(_httpClient), cancellationToken);
 
         /// <inheritdoc />
+        [CLSCompliant(false)]
         public Task<IOrder> DeletePositionAsync(
             DeletePositionRequest request,
             CancellationToken cancellationToken = default) =>

--- a/Alpaca.Markets/AlpacaTradingClient.Orders.cs
+++ b/Alpaca.Markets/AlpacaTradingClient.Orders.cs
@@ -8,6 +8,7 @@ namespace Alpaca.Markets
     public sealed partial class AlpacaTradingClient
     {
         /// <inheritdoc />
+        [CLSCompliant(false)]
         public Task<IReadOnlyList<IOrder>> ListOrdersAsync(
             ListOrdersRequest request,
             CancellationToken cancellationToken = default) =>
@@ -16,12 +17,14 @@ namespace Alpaca.Markets
                 cancellationToken, _alpacaRestApiThrottler);
 
         /// <inheritdoc />
+        [CLSCompliant(false)]
         public Task<IOrder> PostOrderAsync(
             NewOrderRequest request,
             CancellationToken cancellationToken = default) =>
             postOrderAsync(request.EnsureNotNull(nameof(request)).Validate().GetJsonRequest(), cancellationToken);
 
         /// <inheritdoc />
+        [CLSCompliant(false)]
         public Task<IOrder> PostOrderAsync(
             OrderBase orderBase,
             CancellationToken cancellationToken = default) =>
@@ -34,6 +37,7 @@ namespace Alpaca.Markets
                 "v2/orders", jsonNewOrder, cancellationToken);
 
         /// <inheritdoc />
+        [CLSCompliant(false)]
         public Task<IOrder> PatchOrderAsync(
             ChangeOrderRequest request,
             CancellationToken cancellationToken = default) =>
@@ -42,6 +46,7 @@ namespace Alpaca.Markets
                 request, cancellationToken);
 
         /// <inheritdoc />
+        [CLSCompliant(false)]
         public Task<IOrder> GetOrderAsync(
             String clientOrderId,
             CancellationToken cancellationToken = default) =>
@@ -55,6 +60,7 @@ namespace Alpaca.Markets
                 cancellationToken, _alpacaRestApiThrottler);
 
         /// <inheritdoc />
+        [CLSCompliant(false)]
         public Task<IOrder> GetOrderAsync(
             Guid orderId,
             CancellationToken cancellationToken = default) =>

--- a/Alpaca.Markets/Environment/EnvironmentExtensions.cs
+++ b/Alpaca.Markets/Environment/EnvironmentExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Alpaca.Markets
 {
@@ -15,6 +16,7 @@ namespace Alpaca.Markets
         /// <param name="environment">Target environment for new object.</param>
         /// <param name="securityKey">Alpaca API security key.</param>
         /// <returns>The new instance of <see cref="IAlpacaTradingClient"/> interface implementation.</returns>
+        [CLSCompliant(false)]
         public static IAlpacaTradingClient GetAlpacaTradingClient(
             this IEnvironment environment,
             SecurityKey securityKey) =>
@@ -44,6 +46,7 @@ namespace Alpaca.Markets
         /// <param name="environment">Target environment for new object.</param>
         /// <param name="securityKey">Alpaca API security key.</param>
         /// <returns>The new instance of <see cref="IAlpacaDataClient"/> interface implementation.</returns>
+        [CLSCompliant(false)]
         public static IAlpacaDataClient GetAlpacaDataClient(
             this IEnvironment environment,
             SecurityKey securityKey) =>
@@ -73,6 +76,7 @@ namespace Alpaca.Markets
         /// <param name="environment">Target environment for new object.</param>
         /// <param name="securityKey">Alpaca API security key.</param>
         /// <returns>The new instance of <see cref="IAlpacaStreamingClient"/> interface implementation.</returns>
+        [CLSCompliant(false)]
         public static IAlpacaStreamingClient GetAlpacaStreamingClient(
             this IEnvironment environment,
             SecurityKey securityKey) =>
@@ -102,6 +106,7 @@ namespace Alpaca.Markets
         /// <param name="environment">Target environment for new object.</param>
         /// <param name="securityKey">Alpaca API security key.</param>
         /// <returns>The new instance of <see cref="IAlpacaDataStreamingClient"/> interface implementation.</returns>
+        [CLSCompliant(false)]
         public static IAlpacaDataStreamingClient GetAlpacaDataStreamingClient(
             this IEnvironment environment,
             SecurityKey securityKey) =>

--- a/Alpaca.Markets/Helpers/DecimalExtensions.cs
+++ b/Alpaca.Markets/Helpers/DecimalExtensions.cs
@@ -6,5 +6,8 @@ namespace Alpaca.Markets
     {
         public static Int64 AsInteger(this Decimal value) =>
             (Int64) Math.Round(value, MidpointRounding.ToEven);
+        
+        public static UInt64 AsUInteger(this Decimal value) =>
+            (UInt64) Math.Round(value, MidpointRounding.ToEven);
     }
 }

--- a/Alpaca.Markets/Helpers/DecimalExtensions.cs
+++ b/Alpaca.Markets/Helpers/DecimalExtensions.cs
@@ -6,8 +6,5 @@ namespace Alpaca.Markets
     {
         public static Int64 AsInteger(this Decimal value) =>
             (Int64) Math.Round(value, MidpointRounding.ToEven);
-        
-        public static UInt64 AsUInteger(this Decimal value) =>
-            (UInt64) Math.Round(value, MidpointRounding.ToEven);
     }
 }

--- a/Alpaca.Markets/Interfaces/IAccount.cs
+++ b/Alpaca.Markets/Interfaces/IAccount.cs
@@ -7,6 +7,7 @@ namespace Alpaca.Markets
     /// Encapsulates full account information from Alpaca REST API.
     /// </summary>
     [SuppressMessage("ReSharper", "UnusedMemberInSuper.Global")]
+    [CLSCompliant(false)]
     public interface IAccount : IAccountBase
     {
         /// <summary>
@@ -42,7 +43,7 @@ namespace Alpaca.Markets
         /// <summary>
         /// Buying power multiplier that represents account margin classification.
         /// </summary>
-        Int64 Multiplier { get; }
+        Byte Multiplier { get; }
 
         /// <summary>
         /// Current available buying power.
@@ -97,7 +98,7 @@ namespace Alpaca.Markets
         /// <summary>
         /// the current number of day trades that have been made in the last 5 trading days (inclusive of today).
         /// </summary>
-        Int64 DayTradeCount { get; }
+        UInt64 DayTradeCount { get; }
 
         /// <summary>
         /// value of special memorandum account.

--- a/Alpaca.Markets/Interfaces/IAgg.cs
+++ b/Alpaca.Markets/Interfaces/IAgg.cs
@@ -5,6 +5,7 @@ namespace Alpaca.Markets
     /// <summary>
     /// Encapsulates bar information from Polygon REST API.
     /// </summary>
+    [CLSCompliant(false)]
     public interface IAgg : IAggBase
     {
         /// <summary>

--- a/Alpaca.Markets/Interfaces/IAggBase.cs
+++ b/Alpaca.Markets/Interfaces/IAggBase.cs
@@ -7,6 +7,7 @@ namespace Alpaca.Markets
     /// Encapsulates basic bar information for Polygon APIs.
     /// </summary>
     [SuppressMessage("ReSharper", "UnusedMemberInSuper.Global")]
+    [CLSCompliant(false)]
     public interface IAggBase
     {
         /// <summary>
@@ -32,7 +33,7 @@ namespace Alpaca.Markets
         /// <summary>
         /// Gets bar trading volume.
         /// </summary>
-        Int64 Volume { get; }
+        UInt64 Volume { get; }
 
         /// <summary>
         /// Number of items in aggregate window.

--- a/Alpaca.Markets/Interfaces/IAlpacaDataClient.cs
+++ b/Alpaca.Markets/Interfaces/IAlpacaDataClient.cs
@@ -10,6 +10,7 @@ namespace Alpaca.Markets
     /// Provides unified type-safe access for Alpaca Data API via HTTP/REST.
     /// </summary>
     [SuppressMessage("ReSharper", "UnusedMember.Global")]
+    [CLSCompliant(false)]
     public interface IAlpacaDataClient : IDisposable
     {
         /// <summary>

--- a/Alpaca.Markets/Interfaces/IAlpacaDataStreamingClient.cs
+++ b/Alpaca.Markets/Interfaces/IAlpacaDataStreamingClient.cs
@@ -7,6 +7,7 @@ namespace Alpaca.Markets
     /// Provides unified type-safe access for Alpaca data streaming API via websockets.
     /// </summary>
     [SuppressMessage("ReSharper", "UnusedMember.Global")]
+    [CLSCompliant(false)]
     public interface IAlpacaDataStreamingClient : IStreamingDataClient
     {
         /// <summary>

--- a/Alpaca.Markets/Interfaces/IAlpacaStreamingClient.cs
+++ b/Alpaca.Markets/Interfaces/IAlpacaStreamingClient.cs
@@ -7,6 +7,7 @@ namespace Alpaca.Markets
     /// Provides unified type-safe access for Alpaca streaming API.
     /// </summary>
     [SuppressMessage("ReSharper", "EventNeverSubscribedTo.Global")]
+    [CLSCompliant(false)]
     public interface IAlpacaStreamingClient : IStreamingClient
     {
         /// <summary>

--- a/Alpaca.Markets/Interfaces/IAlpacaTradingClient.cs
+++ b/Alpaca.Markets/Interfaces/IAlpacaTradingClient.cs
@@ -10,6 +10,7 @@ namespace Alpaca.Markets
     /// Provides unified type-safe access for Alpaca Trading API via HTTP/REST.
     /// </summary>
     [SuppressMessage("ReSharper", "UnusedMember.Global")]
+    [CLSCompliant(false)]
     public interface IAlpacaTradingClient : IDisposable
     {
         /// <summary>
@@ -126,6 +127,7 @@ namespace Alpaca.Markets
         /// <param name="request">List orders request parameters.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>Read-only list of order information objects.</returns>
+        [CLSCompliant(false)]
         Task<IReadOnlyList<IOrder>> ListOrdersAsync(
             ListOrdersRequest request,
             CancellationToken cancellationToken = default);

--- a/Alpaca.Markets/Interfaces/IExchange.cs
+++ b/Alpaca.Markets/Interfaces/IExchange.cs
@@ -7,12 +7,13 @@ namespace Alpaca.Markets
     /// Encapsulates exchange information from Polygon REST API.
     /// </summary>
     [SuppressMessage("ReSharper", "UnusedMemberInSuper.Global")]
+    [CLSCompliant(false)]
     public interface IExchange
     {
         /// <summary>
         /// Gets exchange unique identifier.
         /// </summary>
-        Int64 ExchangeId { get; }
+        UInt32 ExchangeId { get; }
 
         /// <summary>
         /// Gets exchange type.

--- a/Alpaca.Markets/Interfaces/IHistoricalQuote.cs
+++ b/Alpaca.Markets/Interfaces/IHistoricalQuote.cs
@@ -8,6 +8,7 @@ namespace Alpaca.Markets
     /// </summary>
     [SuppressMessage("ReSharper", "UnusedMember.Global")]
     [SuppressMessage("ReSharper", "UnusedMemberInSuper.Global")]
+    [CLSCompliant(false)]
     // ReSharper disable once PossibleInterfaceMemberAmbiguity
     public interface IHistoricalQuote : IQuoteBase<String>
     {

--- a/Alpaca.Markets/Interfaces/IHistoricalTrade.cs
+++ b/Alpaca.Markets/Interfaces/IHistoricalTrade.cs
@@ -7,6 +7,7 @@ namespace Alpaca.Markets
     /// Encapsulates historical trade information from Polygon REST API.
     /// </summary>
     [SuppressMessage("ReSharper", "UnusedMemberInSuper.Global")]
+    [CLSCompliant(false)]
     public interface IHistoricalTrade
     {
         /// <summary>
@@ -27,12 +28,12 @@ namespace Alpaca.Markets
         /// <summary>
         /// Gets trade quantity.
         /// </summary>
-        Int64 Size { get; }
+        UInt64 Size { get; }
         
         /// <summary>
         /// Gets tape where trade occurred.
         /// </summary>
-        Int64 Tape { get; }
+        UInt64 Tape { get; }
 
         /// <summary>
         /// Gets trade ID.

--- a/Alpaca.Markets/Interfaces/ILastQuote.cs
+++ b/Alpaca.Markets/Interfaces/ILastQuote.cs
@@ -7,6 +7,7 @@ namespace Alpaca.Markets
     /// Encapsulates last quote information from Alpaca REST API.
     /// </summary>
     [SuppressMessage("ReSharper", "UnusedMemberInSuper.Global")]
+    [CLSCompliant(false)]
     public interface ILastQuote : IQuoteBase<Int64>
     {
         /// <summary>

--- a/Alpaca.Markets/Interfaces/ILastTrade.cs
+++ b/Alpaca.Markets/Interfaces/ILastTrade.cs
@@ -8,6 +8,7 @@ namespace Alpaca.Markets
     /// </summary>
     [SuppressMessage("ReSharper", "UnusedMember.Global")]
     [SuppressMessage("ReSharper", "UnusedMemberInSuper.Global")]
+    [CLSCompliant(false)]
     public interface ILastTrade
     {
         /// <summary>
@@ -33,7 +34,7 @@ namespace Alpaca.Markets
         /// <summary>
         /// Gets trade quantity.
         /// </summary>
-        Int64 Size { get; }
+        UInt64 Size { get; }
 
         /// <summary>
         /// Gets trade timestamp.

--- a/Alpaca.Markets/Interfaces/IOrder.cs
+++ b/Alpaca.Markets/Interfaces/IOrder.cs
@@ -9,6 +9,7 @@ namespace Alpaca.Markets
     /// </summary>
     [SuppressMessage("ReSharper", "UnusedMember.Global")]
     [SuppressMessage("ReSharper", "UnusedMemberInSuper.Global")]
+    [CLSCompliant(false)]
     public interface IOrder
     {
         /// <summary>

--- a/Alpaca.Markets/Interfaces/IQuoteBase.cs
+++ b/Alpaca.Markets/Interfaces/IQuoteBase.cs
@@ -8,6 +8,7 @@ namespace Alpaca.Markets
     /// </summary>
     /// <typeparam name="TExchange">Type of bid/ask exchange properties.</typeparam>
     [SuppressMessage("ReSharper", "UnusedMemberInSuper.Global")]
+    [CLSCompliant(false)]
     public interface IQuoteBase<out TExchange>
     {
         /// <summary>
@@ -33,11 +34,11 @@ namespace Alpaca.Markets
         /// <summary>
         /// Gets bid quantity.
         /// </summary>
-        Int64 BidSize { get; }
+        UInt64 BidSize { get; }
 
         /// <summary>
         /// Gets ask quantity.
         /// </summary>
-        Int64 AskSize { get; }
+        UInt64 AskSize { get; }
     }
 }

--- a/Alpaca.Markets/Interfaces/IStreamAgg.cs
+++ b/Alpaca.Markets/Interfaces/IStreamAgg.cs
@@ -7,6 +7,7 @@ namespace Alpaca.Markets
     /// Encapsulates bar information from Polygon streaming API.
     /// </summary>
     [SuppressMessage("ReSharper", "UnusedMemberInSuper.Global")]
+    [CLSCompliant(false)]
     public interface IStreamAgg : IAggBase
     {
         /// <summary>

--- a/Alpaca.Markets/Interfaces/IStreamQuote.cs
+++ b/Alpaca.Markets/Interfaces/IStreamQuote.cs
@@ -7,6 +7,7 @@ namespace Alpaca.Markets
     /// Encapsulates quote information from Polygon streaming API.
     /// </summary>
     [SuppressMessage("ReSharper", "UnusedMemberInSuper.Global")]
+    [CLSCompliant(false)]
     public interface IStreamQuote : IQuoteBase<String>
     {
         /// <summary>

--- a/Alpaca.Markets/Interfaces/IStreamTrade.cs
+++ b/Alpaca.Markets/Interfaces/IStreamTrade.cs
@@ -7,6 +7,7 @@ namespace Alpaca.Markets
     /// Encapsulates trade information from Polygon streaming API.
     /// </summary>
     [SuppressMessage("ReSharper", "UnusedMemberInSuper.Global")]
+    [CLSCompliant(false)]
     public interface IStreamTrade
     {
         /// <summary>
@@ -27,7 +28,7 @@ namespace Alpaca.Markets
         /// <summary>
         /// Gets trade quantity.
         /// </summary>
-        Int64 Size { get; }
+        UInt64 Size { get; }
 
         /// <summary>
         /// Gets trade timestamp in UTC time zone.

--- a/Alpaca.Markets/Interfaces/ITradeUpdate.cs
+++ b/Alpaca.Markets/Interfaces/ITradeUpdate.cs
@@ -7,6 +7,7 @@ namespace Alpaca.Markets
     /// Encapsulates trade update information from Alpaca streaming API.
     /// </summary>
     [SuppressMessage("ReSharper", "UnusedMemberInSuper.Global")]
+    [CLSCompliant(false)]
     public interface ITradeUpdate
     {
         /// <summary>

--- a/Alpaca.Markets/Messages/JsonAccount.cs
+++ b/Alpaca.Markets/Messages/JsonAccount.cs
@@ -48,7 +48,7 @@ namespace Alpaca.Markets
         public Boolean ShortingEnabled { get; set; }
 
         [JsonProperty(PropertyName = "multiplier", Required = Required.Default)]
-        public Int64 Multiplier { get; set; }
+        public Byte Multiplier { get; set; }
 
         [JsonProperty(PropertyName = "buying_power", Required = Required.Always)]
         public Decimal BuyingPower { get; set; }
@@ -81,7 +81,7 @@ namespace Alpaca.Markets
         public Decimal LastMaintenanceMargin { get; set; }
 
         [JsonProperty(PropertyName = "daytrade_count", Required = Required.Default)]
-        public Int64 DayTradeCount { get; set; }
+        public UInt64 DayTradeCount { get; set; }
 
         [JsonProperty(PropertyName = "sma", Required = Required.Default)]
         public Decimal Sma { get; set; }

--- a/Alpaca.Markets/Messages/JsonAlpacaAgg.cs
+++ b/Alpaca.Markets/Messages/JsonAlpacaAgg.cs
@@ -22,7 +22,7 @@ namespace Alpaca.Markets
         public Decimal High { get; set; }
 
         [JsonProperty(PropertyName = "v", Required = Required.Default)]
-        public Int64 Volume { get; set; }
+        public UInt64 Volume { get; set; }
 
         [JsonProperty(PropertyName = "t", Required = Required.Default)]
         [JsonConverter(typeof(UnixSecondsDateTimeConverter))]

--- a/Alpaca.Markets/Messages/JsonAlpacaHistoricalBar.cs
+++ b/Alpaca.Markets/Messages/JsonAlpacaHistoricalBar.cs
@@ -22,7 +22,7 @@ namespace Alpaca.Markets
         public Decimal High { get; set; }
 
         [JsonProperty(PropertyName = "v", Required = Required.Always)]
-        public Int64 Volume { get; set; }
+        public UInt64 Volume { get; set; }
 
         [JsonProperty(PropertyName = "t", Required = Required.Always)]
         public DateTime? TimeUtc { get; set; }

--- a/Alpaca.Markets/Messages/JsonAlpacaHistoricalQuote.cs
+++ b/Alpaca.Markets/Messages/JsonAlpacaHistoricalQuote.cs
@@ -19,7 +19,7 @@ namespace Alpaca.Markets
         public Decimal AskPrice { get; set; }
 
         [JsonProperty(PropertyName = "as", Required = Required.Default)]
-        public Int64 AskSize { get; set; }
+        public UInt64 AskSize { get; set; }
 
         [JsonProperty(PropertyName = "bx", Required = Required.Always)]
         public String BidExchange  { get; set; } = String.Empty;
@@ -28,6 +28,6 @@ namespace Alpaca.Markets
         public Decimal BidPrice { get; set; }
 
         [JsonProperty(PropertyName = "bs", Required = Required.Default)]
-        public Int64 BidSize { get; set; }
+        public UInt64 BidSize { get; set; }
     }
 }

--- a/Alpaca.Markets/Messages/JsonAlpacaHistoricalTrade.cs
+++ b/Alpaca.Markets/Messages/JsonAlpacaHistoricalTrade.cs
@@ -19,12 +19,12 @@ namespace Alpaca.Markets
         public Decimal Price { get; set; }
 
         [JsonProperty(PropertyName = "s", Required = Required.Always)]
-        public Int64 Size { get; set; }
+        public UInt64 Size { get; set; }
 
         [JsonProperty(PropertyName = "z", Required = Required.Default)]
         public String? TradeId { get; set; }
 
         [JsonProperty(PropertyName = "i", Required = Required.Default)]
-        public Int64 Tape { get; set; }
+        public UInt64 Tape { get; set; }
     }
 }

--- a/Alpaca.Markets/Messages/JsonExchange.cs
+++ b/Alpaca.Markets/Messages/JsonExchange.cs
@@ -10,7 +10,7 @@ namespace Alpaca.Markets
     internal sealed class JsonExchange : IExchange
     {
         [JsonProperty(PropertyName = "id", Required = Required.Always)]
-        public Int64 ExchangeId { get; set; }
+        public UInt32 ExchangeId { get; set; }
 
         [JsonProperty(PropertyName = "type", Required = Required.Always)]
         public ExchangeType ExchangeType { get; set; }

--- a/Alpaca.Markets/Messages/JsonLastQuoteAlpaca.cs
+++ b/Alpaca.Markets/Messages/JsonLastQuoteAlpaca.cs
@@ -25,10 +25,10 @@ namespace Alpaca.Markets
             public Decimal AskPrice { get; set; }
 
             [JsonProperty(PropertyName = "bidsize", Required = Required.Default)]
-            public Int64 BidSize { get; set; }
+            public UInt64 BidSize { get; set; }
 
             [JsonProperty(PropertyName = "asksize", Required = Required.Default)]
-            public Int64 AskSize { get; set; }
+            public UInt64 AskSize { get; set; }
 
             [JsonProperty(PropertyName = "timestamp", Required = Required.Always)]
             [JsonConverter(typeof(UnixNanosecondsDateTimeConverter))]
@@ -85,10 +85,10 @@ namespace Alpaca.Markets
         public Decimal AskPrice => Nested.AskPrice;
 
         [JsonIgnore]
-        public Int64 BidSize => Nested.BidSize;
+        public UInt64 BidSize => Nested.BidSize;
 
         [JsonIgnore]
-        public Int64 AskSize => Nested.AskSize;
+        public UInt64 AskSize => Nested.AskSize;
 
         [JsonIgnore]
         public DateTime TimeUtc => Nested.Timestamp;

--- a/Alpaca.Markets/Messages/JsonLastTradeAlpaca.cs
+++ b/Alpaca.Markets/Messages/JsonLastTradeAlpaca.cs
@@ -12,13 +12,13 @@ namespace Alpaca.Markets
         internal struct Last : IEquatable<Last>
         {
             [JsonProperty(PropertyName = "exchange", Required = Required.Always)]
-            public Int64 Exchange { get; set; }
+            public Byte Exchange { get; set; }
 
             [JsonProperty(PropertyName = "price", Required = Required.Always)]
             public Decimal Price { get; set; }
 
             [JsonProperty(PropertyName = "size", Required = Required.Always)]
-            public Int64 Size { get; set; }
+            public UInt64 Size { get; set; }
 
             [JsonProperty(PropertyName = "timestamp", Required = Required.Always)]
             [JsonConverter(typeof(UnixNanosecondsDateTimeConverter))]
@@ -63,7 +63,7 @@ namespace Alpaca.Markets
         public Decimal Price => Nested.Price;
 
         [JsonIgnore]
-        public Int64 Size => Nested.Size;
+        public UInt64 Size => Nested.Size;
 
         [JsonIgnore]
         public DateTime TimeUtc => Nested.Timestamp;

--- a/Alpaca.Markets/Messages/JsonStreamAggAlpaca.cs
+++ b/Alpaca.Markets/Messages/JsonStreamAggAlpaca.cs
@@ -31,7 +31,7 @@ namespace Alpaca.Markets
         public Decimal Average => throw new InvalidOperationException();
 
         [JsonProperty(PropertyName = "v", Required = Required.Always)]
-        public Int64 Volume { get; set; }
+        public UInt64 Volume { get; set; }
 
         [JsonProperty(PropertyName = "t", Required = Required.Always)]
         public DateTime StartTimeUtc { get; set; }

--- a/Alpaca.Markets/Messages/JsonStreamQuoteAlpaca.cs
+++ b/Alpaca.Markets/Messages/JsonStreamQuoteAlpaca.cs
@@ -28,10 +28,10 @@ namespace Alpaca.Markets
         public Decimal AskPrice { get; set; }
 
         [JsonProperty(PropertyName = "bs", Required = Required.Always)]
-        public Int64 BidSize { get; set; }
+        public UInt64 BidSize { get; set; }
 
         [JsonProperty(PropertyName = "as", Required = Required.Always)]
-        public Int64 AskSize { get; set; }
+        public UInt64 AskSize { get; set; }
 
         [JsonProperty(PropertyName = "t", Required = Required.Always)]
         public DateTime TimeUtc { get; set; }

--- a/Alpaca.Markets/Messages/JsonStreamTradeAlpaca.cs
+++ b/Alpaca.Markets/Messages/JsonStreamTradeAlpaca.cs
@@ -25,7 +25,7 @@ namespace Alpaca.Markets
         public Decimal Price { get; set; }
 
         [JsonProperty(PropertyName = "s", Required = Required.Always)]
-        public Int64 Size { get; set; }
+        public UInt64 Size { get; set; }
 
         [JsonProperty(PropertyName = "t", Required = Required.Always)]
         public DateTime TimeUtc { get; set; }

--- a/Alpaca.Markets/PublicAPI.Shipped.txt
+++ b/Alpaca.Markets/PublicAPI.Shipped.txt
@@ -258,7 +258,7 @@ Alpaca.Markets.HistoryPeriodUnit.Year = 3 -> Alpaca.Markets.HistoryPeriodUnit
 Alpaca.Markets.IAccount
 Alpaca.Markets.IAccount.AccountNumber.get -> string?
 Alpaca.Markets.IAccount.BuyingPower.get -> decimal
-Alpaca.Markets.IAccount.DayTradeCount.get -> long
+Alpaca.Markets.IAccount.DayTradeCount.get -> ulong
 Alpaca.Markets.IAccount.DayTradingBuyingPower.get -> decimal
 Alpaca.Markets.IAccount.Equity.get -> decimal
 Alpaca.Markets.IAccount.InitialMargin.get -> decimal
@@ -270,7 +270,7 @@ Alpaca.Markets.IAccount.LastEquity.get -> decimal
 Alpaca.Markets.IAccount.LastMaintenanceMargin.get -> decimal
 Alpaca.Markets.IAccount.LongMarketValue.get -> decimal
 Alpaca.Markets.IAccount.MaintenanceMargin.get -> decimal
-Alpaca.Markets.IAccount.Multiplier.get -> long
+Alpaca.Markets.IAccount.Multiplier.get -> byte
 Alpaca.Markets.IAccount.RegulationBuyingPower.get -> decimal
 Alpaca.Markets.IAccount.ShortingEnabled.get -> bool
 Alpaca.Markets.IAccount.ShortMarketValue.get -> decimal
@@ -322,7 +322,7 @@ Alpaca.Markets.IAggBase.High.get -> decimal
 Alpaca.Markets.IAggBase.ItemsInWindow.get -> int
 Alpaca.Markets.IAggBase.Low.get -> decimal
 Alpaca.Markets.IAggBase.Open.get -> decimal
-Alpaca.Markets.IAggBase.Volume.get -> long
+Alpaca.Markets.IAggBase.Volume.get -> ulong
 Alpaca.Markets.IAlpacaDataClient
 Alpaca.Markets.IAlpacaDataClient.GetBarSetAsync(Alpaca.Markets.BarSetRequest! request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlyList<Alpaca.Markets.IAgg!>!>!>!
 Alpaca.Markets.IAlpacaDataClient.GetLastQuoteAsync(string! symbol, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Alpaca.Markets.ILastQuote!>!
@@ -406,7 +406,7 @@ Alpaca.Markets.IEnvironment.AlpacaDataStreamingApi.get -> System.Uri!
 Alpaca.Markets.IEnvironment.AlpacaStreamingApi.get -> System.Uri!
 Alpaca.Markets.IEnvironment.AlpacaTradingApi.get -> System.Uri!
 Alpaca.Markets.IExchange
-Alpaca.Markets.IExchange.ExchangeId.get -> long
+Alpaca.Markets.IExchange.ExchangeId.get -> uint
 Alpaca.Markets.IExchange.ExchangeType.get -> Alpaca.Markets.ExchangeType
 Alpaca.Markets.IExchange.MarketDataType.get -> Alpaca.Markets.MarketDataType
 Alpaca.Markets.IExchange.MarketIdentificationCode.get -> string?
@@ -425,8 +425,8 @@ Alpaca.Markets.IHistoricalQuote.TimestampUtc.get -> System.DateTime
 Alpaca.Markets.IHistoricalTrade
 Alpaca.Markets.IHistoricalTrade.Exchange.get -> string!
 Alpaca.Markets.IHistoricalTrade.Price.get -> decimal
-Alpaca.Markets.IHistoricalTrade.Size.get -> long
-Alpaca.Markets.IHistoricalTrade.Tape.get -> long
+Alpaca.Markets.IHistoricalTrade.Size.get -> ulong
+Alpaca.Markets.IHistoricalTrade.Tape.get -> ulong
 Alpaca.Markets.IHistoricalTrade.TimestampUtc.get -> System.DateTime
 Alpaca.Markets.IHistoricalTrade.TradeId.get -> string?
 Alpaca.Markets.IInclusiveTimeInterval
@@ -437,7 +437,7 @@ Alpaca.Markets.ILastQuote.TimeUtc.get -> System.DateTime
 Alpaca.Markets.ILastTrade
 Alpaca.Markets.ILastTrade.Exchange.get -> long
 Alpaca.Markets.ILastTrade.Price.get -> decimal
-Alpaca.Markets.ILastTrade.Size.get -> long
+Alpaca.Markets.ILastTrade.Size.get -> ulong
 Alpaca.Markets.ILastTrade.Status.get -> string!
 Alpaca.Markets.ILastTrade.Symbol.get -> string!
 Alpaca.Markets.ILastTrade.TimeUtc.get -> System.DateTime
@@ -511,9 +511,9 @@ Alpaca.Markets.IQuoteBase<TExchange>
 Alpaca.Markets.IQuoteBase<TExchange>.AskExchange.get -> TExchange
 Alpaca.Markets.IQuoteBase<TExchange>.BidExchange.get -> TExchange
 Alpaca.Markets.IQuoteBase<TExchange>.AskPrice.get -> decimal
-Alpaca.Markets.IQuoteBase<TExchange>.AskSize.get -> long
+Alpaca.Markets.IQuoteBase<TExchange>.AskSize.get -> ulong
 Alpaca.Markets.IQuoteBase<TExchange>.BidPrice.get -> decimal
-Alpaca.Markets.IQuoteBase<TExchange>.BidSize.get -> long
+Alpaca.Markets.IQuoteBase<TExchange>.BidSize.get -> ulong
 Alpaca.Markets.IRequestWithTimeInterval<TInterval>
 Alpaca.Markets.IRequestWithTimeInterval<TInterval>.SetInterval(TInterval value) -> void
 Alpaca.Markets.IStopLoss
@@ -545,7 +545,7 @@ Alpaca.Markets.IStreamQuote.TimeUtc.get -> System.DateTime
 Alpaca.Markets.IStreamTrade
 Alpaca.Markets.IStreamTrade.Exchange.get -> string!
 Alpaca.Markets.IStreamTrade.Price.get -> decimal
-Alpaca.Markets.IStreamTrade.Size.get -> long
+Alpaca.Markets.IStreamTrade.Size.get -> ulong
 Alpaca.Markets.IStreamTrade.Symbol.get -> string!
 Alpaca.Markets.IStreamTrade.TimeUtc.get -> System.DateTime
 Alpaca.Markets.IStreamTrade.TradeId.get -> string!

--- a/GlobalSuppressions.cs
+++ b/GlobalSuppressions.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: CLSCompliant(false)]
+[assembly: CLSCompliant(true)]
 
 [assembly: SuppressMessage("Globalization",
     "CA1303: Do not pass literals as localized parameters",

--- a/GlobalSuppressions.cs
+++ b/GlobalSuppressions.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: CLSCompliant(true)]
+[assembly: CLSCompliant(false)]
 
 [assembly: SuppressMessage("Globalization",
     "CA1303: Do not pass literals as localized parameters",


### PR DESCRIPTION
This is a first pass run through to fix https://github.com/alpacahq/alpaca-trade-api-csharp/issues/283. Familiarize yourself with [Dot Net Data Types](https://docs.microsoft.com/en-us/dotnet/visual-basic/language-reference/data-types/) if it's helpful!

In several places, the signed Int64 data type is used, when a UInt64 data type could, and should, be used. For example:

* Volume in a trade
* Bid/ask sizes

This PR converts those variables to use UInt64. I truly considered whether UInt64 was the right choice, because it's upper boundary is an insane 1.8...E+19. UInt32 (upper bound 4,294,967,295) might be a more realistic choice.

Similarly, in at least one case (`Multiplier`), it _did_ make sense to drop the size completely. Multiplier [only has three values](https://alpaca.markets/docs/api-documentation/api-v2/account/) currently: 1, 2, and 4. Perhaps it would also make sense as an enum.

There is one more PR I'd like to make. Several utilities, like this one, also have quite large data types:

https://github.com/alpacahq/alpaca-trade-api-csharp/blob/353dc450efff6e24ba972a823dcc30277bddbdab/Alpaca.Markets/Helpers/DateTimeHelper.cs#L8-L11

It should be noted that currently, quantities _are_ kept at Int64; this is because negative values can be used when placing short orders:

https://github.com/alpacahq/alpaca-trade-api-csharp/blob/3dbbbfe55afef6fe95f9bca7df7ef0cf552272c1/UsageExamples/MeanReversionBrokerage.cs#L196-L203