### PR TITLE
Upgrade to GitHub-native Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+- package-ecosystem: nuget
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "04:00"
+  open-pull-requests-limit: 10
+  assignees:
+  - OlegRa
+  ignore:
+  - dependency-name: Alpaca.Markets
+    versions:
+    - "> 5.0.3-alpha3"
+  - dependency-name: Alpaca.Markets
+    versions:
+    - 5.0.0-alpha3
+    - 5.0.1-alpha2
+    - 5.0.1-alpha3
+    - 5.0.1-alpha4
+    - 5.0.3-alpha2
+  - dependency-name: docfx.console
+    versions:
+    - 2.56.7
+    - 2.57.0
+    - 2.57.1
+    - 2.57.2
+  - dependency-name: JetBrains.Annotations
+    versions:
+    - 2021.1.0
+  - dependency-name: Newtonsoft.Json
+    versions:
+    - 13.0.1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,26 +8,3 @@ updates:
   open-pull-requests-limit: 10
   assignees:
   - OlegRa
-  ignore:
-  - dependency-name: Alpaca.Markets
-    versions:
-    - "> 5.0.3-alpha3"
-  - dependency-name: Alpaca.Markets
-    versions:
-    - 5.0.0-alpha3
-    - 5.0.1-alpha2
-    - 5.0.1-alpha3
-    - 5.0.1-alpha4
-    - 5.0.3-alpha2
-  - dependency-name: docfx.console
-    versions:
-    - 2.56.7
-    - 2.57.0
-    - 2.57.1
-    - 2.57.2
-  - dependency-name: JetBrains.Annotations
-    versions:
-    - 2021.1.0
-  - dependency-name: Newtonsoft.Json
-    versions:
-    - 13.0.1


### PR DESCRIPTION
_Dependabot Preview will be shut down on August 3rd, 2021. In order to keep getting Dependabot updates, please merge this PR and migrate to GitHub-native Dependabot before then._

Dependabot has been fully integrated into GitHub, so you no longer have to install and manage a separate app. This pull request migrates your configuration from Dependabot.com to a config file, using the [new syntax][new_syntax]. When merged, we'll swap out `dependabot-preview` (me) for a new `dependabot` app, and you'll be all set!

With this change, you'll now use the [Dependabot page in GitHub][dependabot_page], rather than the [Dependabot dashboard][dashboard], to monitor your version updates, and you'll configure Dependabot through the new config file rather than a UI.







If you've got any questions or feedback for us, please let us know by creating an issue in the [dependabot/dependabot-core][issues] repository.

[Learn more about migrating to GitHub-native Dependabot][learn]

Please note that regular `@dependabot` commands do not work on this pull request.

[dashboard]: https://app.dependabot.com/
[dependabot_page]: https://github.com/OlegRa/Alpaca.Markets/network/updates
[issues]: https://github.com/dependabot/dependabot-core/issues/new?assignees=%40dependabot%2Fpreview-migration-reviewers&labels=E%3A+preview-migration&template=migration-issue.md
[learn]: http://docs.github.com/code-security/supply-chain-security/upgrading-from-dependabotcom-to-github-native-dependabot
[new_syntax]: https://help.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
[org_secrets_url]: https://github.com/settings/secrets/dependabot
[repo_secrets_url]: https://github.com/OlegRa/Alpaca.Markets/settings/secrets/dependabot
