### PR TITLE
Added missing Name field to IAsset.

### DIFF
--- a/Alpaca.Markets/Interfaces/IAsset.cs
+++ b/Alpaca.Markets/Interfaces/IAsset.cs
@@ -28,9 +28,14 @@ namespace Alpaca.Markets
         Exchange Exchange { get; }
 
         /// <summary>
-        /// Gets asset name.
+        /// Gets asset symbol.
         /// </summary>
         String Symbol { get; }
+
+        /// <summary>
+        /// Gets asset name.
+        /// </summary>
+        String Name { get; }
 
         /// <summary>
         /// Get asset status in API.

--- a/Alpaca.Markets/Messages/JsonAsset.cs
+++ b/Alpaca.Markets/Messages/JsonAsset.cs
@@ -21,6 +21,9 @@ namespace Alpaca.Markets
         [JsonProperty(PropertyName = "symbol", Required = Required.Always)]
         public String Symbol { get; set; } = String.Empty;
 
+        [JsonProperty(PropertyName = "name", Required = Required.Always)]
+        public String Name { get; set; } = String.Empty;
+
         [JsonProperty(PropertyName = "status", Required = Required.Always)]
         public AssetStatus Status { get; set; }
 

--- a/Alpaca.Markets/PublicAPI.Shipped.txt
+++ b/Alpaca.Markets/PublicAPI.Shipped.txt
@@ -311,6 +311,7 @@ Alpaca.Markets.IAsset.Marginable.get -> bool
 Alpaca.Markets.IAsset.Shortable.get -> bool
 Alpaca.Markets.IAsset.Status.get -> Alpaca.Markets.AssetStatus
 Alpaca.Markets.IAsset.Symbol.get -> string!
+Alpaca.Markets.IAsset.Name.get -> string!
 Alpaca.Markets.IBar
 Alpaca.Markets.IBar.Close.get -> decimal
 Alpaca.Markets.IBar.High.get -> decimal


### PR DESCRIPTION
I have added the missing Name field for IAsset and JsonAsset classes, as well as adding it to the PublicAPI.Shipped.txt since it is a field that is available via directly querying the API. 