### PR TITLE
Address issue where a request with null quotes will cause a crash

### DIFF
--- a/Alpaca.Markets/Messages/JsonQuotesPage.cs
+++ b/Alpaca.Markets/Messages/JsonQuotesPage.cs
@@ -11,7 +11,7 @@ namespace Alpaca.Markets
         Justification = "Object instances of this class will be created by Newtonsoft.JSON library.")]
     internal sealed class JsonQuotesPage : IPage<IQuote>
     {
-        [JsonProperty(PropertyName = "quotes", Required = Required.Always)]
+        [JsonProperty(PropertyName = "quotes", Required = Required.Default)]
         public List<JsonHistoricalQuote> ItemsList { get; set; } = new ();
 
         [JsonProperty(PropertyName = "symbol", Required = Required.Always)]


### PR DESCRIPTION
Data API doesn't gurantee `non-null`. E.g:
````
GET https://data.alpaca.markets/v2/stocks/CNM/quotes?limit=10000&start=2021-03-29T00%3A00%3A00.0000000-04%3A00&end=2021-03-29T00%3A00%3A00.0000000-04%3A00 HTTP/1.1
````