### PR TITLE
added INACTIVE accounts enum

### DIFF
--- a/Alpaca.Markets/Enums/AccountStatus.cs
+++ b/Alpaca.Markets/Enums/AccountStatus.cs
@@ -74,5 +74,12 @@ public enum AccountStatus
     /// </summary>
     [UsedImplicitly]
     [EnumMember(Value = "APPROVED")]
-    Approved
+    Approved,
+
+    /// <summary>
+    /// Account approved but not active.
+    /// </summary>
+    [UsedImplicitly]
+    [EnumMember(Value = "INACTIVE")]
+    Inactive
 }

--- a/Alpaca.Markets/PublicAPI.Shipped.txt
+++ b/Alpaca.Markets/PublicAPI.Shipped.txt
@@ -56,6 +56,7 @@ Alpaca.Markets.AccountStatus.AccountUpdated = 3 -> Alpaca.Markets.AccountStatus
 Alpaca.Markets.AccountStatus.Active = 5 -> Alpaca.Markets.AccountStatus
 Alpaca.Markets.AccountStatus.ApprovalPending = 4 -> Alpaca.Markets.AccountStatus
 Alpaca.Markets.AccountStatus.Approved = 9 -> Alpaca.Markets.AccountStatus
+Alpaca.Markets.AccountStatus.Inactive = 10 -> Alpaca.Markets.AccountStatus
 Alpaca.Markets.AccountStatus.Disabled = 7 -> Alpaca.Markets.AccountStatus
 Alpaca.Markets.AccountStatus.DisablePending = 8 -> Alpaca.Markets.AccountStatus
 Alpaca.Markets.AccountStatus.Onboarding = 0 -> Alpaca.Markets.AccountStatus


### PR DESCRIPTION
Added INACTIVE Enum to Accounts, not having this value started causing errors today in a crypto_status field.  Error was:

```cs
Exception thrown: 'Newtonsoft.Json.JsonSerializationException' in mscorlib.dll
System.AggregateException: One or more errors occurred. ---> Newtonsoft.Json.JsonSerializationException: Error converting value "INACTIVE" to type 'Alpaca.Markets.AccountStatus'. Path 'crypto_status', line 1, position 118. ---> System.ArgumentException: Requested value 'INACTIVE' was not found.
   at Newtonsoft.Json.Utilities.EnumUtils.ParseEnum(Type enumType, NamingStrategy namingStrategy, String value, Boolean disallowNumber)
   at Newtonsoft.Json.Converters.StringEnumConverter.ReadJson(JsonReader reader, Type objectType, Object existingValue, JsonSerializer serializer)
   --- End of inner exception stack trace ---
   at Newtonsoft.Json.Converters.StringEnumConverter.ReadJson(JsonReader reader, Type objectType, Object existingValue, JsonSerializer serializer)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.DeserializeConvertable(JsonConverter converter, JsonReader reader, Type objectType, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonSerializer.Deserialize[T](JsonReader reader)
   at Alpaca.Markets.HttpResponseMethodExtensions.<DeserializeAsync>d__0`2.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Alpaca.Markets.HttpClientExtensions.<callAndDeserializeAsync>d__6`2.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Alpaca.Markets.HttpClientExtensions.<callAndDeserializeAsync>d__4`2.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at StockTitan.frmAlpacaBotHourly.<initAPI>d__106.MoveNext() in F:\source\stocks\ST\Forms\frmAlpacaBotHourly.cs:line 404
   --- End of inner exception stack trace ---
---> (Inner Exception #0) Newtonsoft.Json.JsonSerializationException: Error converting value "INACTIVE" to type 'Alpaca.Markets.AccountStatus'. Path 'crypto_status', line 1, position 118. ---> System.ArgumentException: Requested value 'INACTIVE' was not found.
   at Newtonsoft.Json.Utilities.EnumUtils.ParseEnum(Type enumType, NamingStrategy namingStrategy, String value, Boolean disallowNumber)
   at Newtonsoft.Json.Converters.StringEnumConverter.ReadJson(JsonReader reader, Type objectType, Object existingValue, JsonSerializer serializer)
   --- End of inner exception stack trace ---
   at Newtonsoft.Json.Converters.StringEnumConverter.ReadJson(JsonReader reader, Type objectType, Object existingValue, JsonSerializer serializer)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.DeserializeConvertable(JsonConverter converter, JsonReader reader, Type objectType, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonSerializer.Deserialize[T](JsonReader reader)
   at Alpaca.Markets.HttpResponseMethodExtensions.<DeserializeAsync>d__0`2.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Alpaca.Markets.HttpClientExtensions.<callAndDeserializeAsync>d__6`2.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Alpaca.Markets.HttpClientExtensions.<callAndDeserializeAsync>d__4`2.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at StockTitan.frmAlpacaBotHourly.<initAPI>d__106.MoveNext() in F:\source\stocks\ST\Forms\frmAlpacaBotHourly.cs:line 404<---
```

Line 404 is:

```cs
accountLive = await clientLive.GetAccountAsync();
```