### PR TITLE
JsonAnnouncement's RecordDate should be able to parse to null.

### DIFF
--- a/Alpaca.Markets/Messages/JsonAnnouncement.cs
+++ b/Alpaca.Markets/Messages/JsonAnnouncement.cs
@@ -38,7 +38,7 @@ internal sealed class JsonAnnouncement : IAnnouncement
     public DateOnly? ExecutionDate { get; [ExcludeFromCodeCoverage] set; }
 
     [JsonConverter(typeof(DateOnlyConverter))]
-    [JsonProperty(PropertyName = "record_date", Required = Required.Always)]
+    [JsonProperty(PropertyName = "record_date", Required = Required.AllowNull)]
     public DateOnly? RecordDate { get; set; }
 
     [JsonConverter(typeof(DateOnlyConverter))]


### PR DESCRIPTION
## Description
Currently GetAnnouncementAsync and ListAnnouncementsAsync might fail when record_date is null.
In that case, an unhandled exception occurs.
Checking the API reference on https://paper-api.alpaca.markets/v2/corporate_actions/announcements shows that record_date is returned as null quite often.

Fixes # ([657](https://github.com/alpacahq/alpaca-trade-api-csharp/issues/657))

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Reproduction:
Execute ListAnnouncementsAsync with a StartDate of 2023-08-01 and EndDate of 2023-08-20.

Code sample:
```cs
var actionTypes = new CorporateActionType[] { CorporateActionType.Dividend, CorporateActionType.Merger, CorporateActionType.SpinOff, CorporateActionType.Split };
var interval = new Interval<DateOnly>(DateOnly.FromDateTime(startDate), DateOnly.FromDateTime(endDate));
var announcementsRequest = new AnnouncementsRequest(actionTypes.ToList(), interval);
var announcements = await _tradingClient.ListAnnouncementsAsync(announcementsRequest, cancellationToken);
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
