### PR TITLE
Update OpenClose.cs - make constructor public

### DIFF
--- a/Alpaca.Markets/Helpers/OpenClose.cs
+++ b/Alpaca.Markets/Helpers/OpenClose.cs
@@ -20,7 +20,7 @@ public readonly record struct OpenClose
     /// <param name="date">Session date</param>
     /// <param name="open">Open time in EST time zone.</param>
     /// <param name="close">Close time in EST time zone.</param>
-    internal OpenClose(
+    public OpenClose(
         DateOnly date,
         TimeOnly open,
         TimeOnly close)

--- a/Alpaca.Markets/Helpers/OpenClose.cs
+++ b/Alpaca.Markets/Helpers/OpenClose.cs
@@ -20,7 +20,7 @@ public readonly record struct OpenClose
     /// <param name="date">Session date</param>
     /// <param name="open">Open time in EST time zone.</param>
     /// <param name="close">Close time in EST time zone.</param>
-    public OpenClose(
+    internal OpenClose(
         DateOnly date,
         TimeOnly open,
         TimeOnly close)
@@ -32,12 +32,12 @@ public readonly record struct OpenClose
     /// <summary>
     /// Gets open time in EST time zone.
     /// </summary>
-    public DateTimeOffset OpenEst { get; }
+    public DateTimeOffset OpenEst { get; init; }
 
     /// <summary>
     /// Gets close time in EST time zone.
     /// </summary>
-    public DateTimeOffset CloseEst { get; }
+    public DateTimeOffset CloseEst { get; init; }
 
     /// <summary>
     /// Gets session open and close time as <see cref="Interval{DateTime}"/> instance with UTC times.

--- a/Alpaca.Markets/PublicAPI.Shipped.txt
+++ b/Alpaca.Markets/PublicAPI.Shipped.txt
@@ -940,8 +940,10 @@ Alpaca.Markets.OneCancelsOtherOrder.StopLoss.get -> Alpaca.Markets.IStopLoss!
 Alpaca.Markets.OneCancelsOtherOrder.TakeProfit.get -> Alpaca.Markets.ITakeProfit!
 Alpaca.Markets.OpenClose
 Alpaca.Markets.OpenClose.CloseEst.get -> System.DateTimeOffset
+Alpaca.Markets.OpenClose.CloseEst.init -> void
 Alpaca.Markets.OpenClose.OpenClose() -> void
 Alpaca.Markets.OpenClose.OpenEst.get -> System.DateTimeOffset
+Alpaca.Markets.OpenClose.OpenEst.init -> void
 Alpaca.Markets.OpenClose.ToInterval() -> Alpaca.Markets.Interval<System.DateTime>
 Alpaca.Markets.OptionContractsRequest
 Alpaca.Markets.OptionContractsRequest.AssetStatus.get -> Alpaca.Markets.AssetStatus?


### PR DESCRIPTION
## Description

make the openclose struct constructor public so we can construct instances of these to aid in testing.

Fixes # (issue)

OpenClose.cs

## Type of change

made an internal constructor public

## How Has This Been Tested?

ran unit tests for project

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
