### PR TITLE
Dependencies update (Dependabot)

### DIFF
--- a/Alpaca.Markets.Extensions.Tests/Alpaca.Markets.Extensions.Tests.csproj
+++ b/Alpaca.Markets.Extensions.Tests/Alpaca.Markets.Extensions.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="xunit" Version="2.9.0" />

--- a/Alpaca.Markets.Extensions.Tests/Alpaca.Markets.Extensions.Tests.csproj
+++ b/Alpaca.Markets.Extensions.Tests/Alpaca.Markets.Extensions.Tests.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/Alpaca.Markets.Extensions/packages.lock.json
+++ b/Alpaca.Markets.Extensions/packages.lock.json
@@ -266,8 +266,8 @@
       },
       "System.Net.Http.WinHttpHandler": {
         "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "xftE9w7kEH2GuOJV+X8zjAzsRE7NZgGy5i8ayGJZia2b69ymYq3tbGhoxnZJO8rsu7ERwtv3TmKdiglk9wTn9A==",
+        "resolved": "8.0.2",
+        "contentHash": "PNtuWFl55FSigmCWX+Rj3h/1C5igGw3G4+cvnEe2kkwMDSWX08L/GuBw5S5Fc8R9PvOj+CRUHMY9w/Va8MKWHQ==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5"
@@ -303,7 +303,7 @@
           "Polly": "[8.4.1, )",
           "Portable.System.DateTimeOnly": "[8.0.1, )",
           "System.IO.Pipelines": "[8.0.0, )",
-          "System.Net.Http.WinHttpHandler": "[8.0.1, )",
+          "System.Net.Http.WinHttpHandler": "[8.0.2, )",
           "System.Threading.Channels": "[8.0.0, )"
         }
       }

--- a/Alpaca.Markets.Tests/Alpaca.Markets.Tests.csproj
+++ b/Alpaca.Markets.Tests/Alpaca.Markets.Tests.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />

--- a/Alpaca.Markets.Tests/Alpaca.Markets.Tests.csproj
+++ b/Alpaca.Markets.Tests/Alpaca.Markets.Tests.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/Alpaca.Markets.Tests/Alpaca.Markets.Tests.csproj
+++ b/Alpaca.Markets.Tests/Alpaca.Markets.Tests.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageReference Include="xunit" Version="2.9.0" />

--- a/Alpaca.Markets/Alpaca.Markets.csproj
+++ b/Alpaca.Markets/Alpaca.Markets.csproj
@@ -110,7 +110,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
-    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="8.0.1" PrivateAssets="compile;contentfiles;build;analyzers" />
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="8.0.2" PrivateAssets="compile;contentfiles;build;analyzers" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/Alpaca.Markets/packages.lock.json
+++ b/Alpaca.Markets/packages.lock.json
@@ -76,9 +76,9 @@
       },
       "System.Net.Http.WinHttpHandler": {
         "type": "Direct",
-        "requested": "[8.0.1, )",
-        "resolved": "8.0.1",
-        "contentHash": "xftE9w7kEH2GuOJV+X8zjAzsRE7NZgGy5i8ayGJZia2b69ymYq3tbGhoxnZJO8rsu7ERwtv3TmKdiglk9wTn9A==",
+        "requested": "[8.0.2, )",
+        "resolved": "8.0.2",
+        "contentHash": "PNtuWFl55FSigmCWX+Rj3h/1C5igGw3G4+cvnEe2kkwMDSWX08L/GuBw5S5Fc8R9PvOj+CRUHMY9w/Va8MKWHQ==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.5"

--- a/UsageExamples/UsageExamples.csproj
+++ b/UsageExamples/UsageExamples.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
-    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="8.0.1" />
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="8.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Bump `System.Net.Http.WinHttpHandler` from 8.0.1 to 8.0.2
- Bump `Microsoft.Extensions.Http.Polly` from 8.0.7 to 8.0.8
- Bump `Microsoft.NET.Test.Sdk` from 17.10.0 to 17.11.1
- Bump `Moq` from 4.20.70 to 4.20.72