### PR TITLE
Add support for the delayed SIP feed

### DIFF
--- a/Alpaca.Markets.Tests/AlpacaDataClientTest.Snapshot.cs
+++ b/Alpaca.Markets.Tests/AlpacaDataClientTest.Snapshot.cs
@@ -28,7 +28,7 @@ public sealed partial class AlpacaDataClientTest
         var snapshots = await mock.Client
             .ListSnapshotsAsync(new LatestMarketDataListRequest(_symbols)
             {
-                Feed = MarketDataFeed.Otc,
+                Feed = MarketDataFeed.DelayedSip,
                 Currency = Currency
             });
 

--- a/Alpaca.Markets/Enums/MarketDataFeed.cs
+++ b/Alpaca.Markets/Enums/MarketDataFeed.cs
@@ -25,5 +25,14 @@ public enum MarketDataFeed
     /// </summary>
     [UsedImplicitly]
     [EnumMember(Value = "otc")]
-    Otc
+    Otc,
+
+    /// <summary>
+    /// DelayedSIP feed - 15-minute delayed <see cref="Sip"/>. It can only be used
+    /// in the latest endpoints and on the stream. For historical endpoints you can
+    /// simply use <see cref="Sip"/> and set the end parameter to 15 minutes ago.
+    /// </summary>
+    [UsedImplicitly]
+    [EnumMember(Value = "delayed_sip")]
+    DelayedSip
 }

--- a/Alpaca.Markets/PublicAPI.Shipped.txt
+++ b/Alpaca.Markets/PublicAPI.Shipped.txt
@@ -1053,6 +1053,7 @@ Alpaca.Markets.ListOrdersRequest.WithInterval(Alpaca.Markets.Interval<System.Dat
 Alpaca.Markets.ListOrdersRequest.WithSymbol(string! symbol) -> Alpaca.Markets.ListOrdersRequest!
 Alpaca.Markets.ListOrdersRequest.WithSymbols(System.Collections.Generic.IEnumerable<string!>! symbols) -> Alpaca.Markets.ListOrdersRequest!
 Alpaca.Markets.MarketDataFeed
+Alpaca.Markets.MarketDataFeed.DelayedSip = 3 -> Alpaca.Markets.MarketDataFeed
 Alpaca.Markets.MarketDataFeed.Iex = 0 -> Alpaca.Markets.MarketDataFeed
 Alpaca.Markets.MarketDataFeed.Otc = 2 -> Alpaca.Markets.MarketDataFeed
 Alpaca.Markets.MarketDataFeed.Sip = 1 -> Alpaca.Markets.MarketDataFeed


### PR DESCRIPTION
## Description

The `DelayedSip` member was added to the `MarketDataFeed` enumeration.
Fixes #781

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
