### PR TITLE
Updated trading api uri used by paper environment

### DIFF
--- a/Alpaca.Markets/Environment/PaperEnvironment.cs
+++ b/Alpaca.Markets/Environment/PaperEnvironment.cs
@@ -2,7 +2,7 @@
 
 internal sealed class PaperEnvironment : IEnvironment
 {
-    public Uri AlpacaTradingApi => new("https://paper-api.alpaca.markets");
+    public Uri AlpacaTradingApi => new("https://paper-api.alpaca.markets/v2");
 
     public Uri AlpacaDataApi => Environments.Live.AlpacaDataApi;
 


### PR DESCRIPTION
## Description

Currently, attempting to access client information from a Paper environment within a C# application returns forbidden access errors.

This seems to be due to outdated API URI provided within the current version of the nuget package.

Fixes #784

Updated paper trading API to version 2!

## Type of change

- Bug fix (non-breaking change which fixes an issue)
