### PR TITLE
Fix JSON deserialization issues

### DIFF
--- a/Alpaca.Markets.Tests/AlpacaTradingClientTest.Assets.cs
+++ b/Alpaca.Markets.Tests/AlpacaTradingClientTest.Assets.cs
@@ -51,7 +51,8 @@ public sealed partial class AlpacaTradingClientTest
         new(
             new JProperty("attributes", new JArray(
                 toEnumString(AssetAttributes.PtpNoException))),
-            new JProperty("maintenance_margin_requirement", 100),
+            new JProperty("margin_requirement_short", 100),
+            new JProperty("margin_requirement_long", 100),
             new JProperty("status", AssetStatus.Active),
             new JProperty("class", AssetClass.UsEquity),
             new JProperty("exchange", Exchange.Amex),
@@ -90,7 +91,8 @@ public sealed partial class AlpacaTradingClientTest
         Assert.NotNull(asset.MinOrderSize);
         Assert.NotNull(asset.PriceIncrement);
         Assert.NotNull(asset.MinTradeIncrement);
-        Assert.NotNull(asset.MaintenanceMarginRequirement);
+        Assert.NotNull(asset.MarginRequirementLong);
+        Assert.NotNull(asset.MarginRequirementShort);
 
         Assert.Single(asset.Attributes);
         Assert.Equal(AssetAttributes.PtpNoException, asset.Attributes[0]);

--- a/Alpaca.Markets.sln.DotSettings
+++ b/Alpaca.Markets.sln.DotSettings
@@ -34,6 +34,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=OPRA/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=orderbooks/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=OTOCO/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=perp/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Ratelimit/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Recapitalizaiton/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Screener/@EntryIndexedValue">True</s:Boolean>

--- a/Alpaca.Markets/CompatibilitySuppressions.xml
+++ b/Alpaca.Markets/CompatibilitySuppressions.xml
@@ -577,6 +577,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Alpaca.Markets.IPortfolioHistory.get_BaseValue</Target>
+    <Left>lib/net462/Alpaca.Markets.dll</Left>
+    <Right>lib/net462/Alpaca.Markets.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Alpaca.Markets.LatestDataListRequest.#ctor(System.Collections.Generic.IEnumerable{System.String},Alpaca.Markets.CryptoExchange)</Target>
     <Left>lib/net462/Alpaca.Markets.dll</Left>
     <Right>lib/net462/Alpaca.Markets.dll</Right>
@@ -899,6 +906,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Alpaca.Markets.IPortfolioHistory.get_BaseValue</Target>
+    <Left>lib/net6.0/Alpaca.Markets.dll</Left>
+    <Right>lib/netstandard2.1/Alpaca.Markets.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Alpaca.Markets.LatestDataListRequest.#ctor(System.Collections.Generic.IEnumerable{System.String},Alpaca.Markets.CryptoExchange)</Target>
     <Left>lib/net6.0/Alpaca.Markets.dll</Left>
     <Right>lib/netstandard2.1/Alpaca.Markets.dll</Right>
@@ -1221,6 +1235,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Alpaca.Markets.IPortfolioHistory.get_BaseValue</Target>
+    <Left>lib/netstandard2.0/Alpaca.Markets.dll</Left>
+    <Right>lib/netstandard2.0/Alpaca.Markets.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Alpaca.Markets.LatestDataListRequest.#ctor(System.Collections.Generic.IEnumerable{System.String},Alpaca.Markets.CryptoExchange)</Target>
     <Left>lib/netstandard2.0/Alpaca.Markets.dll</Left>
     <Right>lib/netstandard2.0/Alpaca.Markets.dll</Right>
@@ -1543,6 +1564,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Alpaca.Markets.IPortfolioHistory.get_BaseValue</Target>
+    <Left>lib/netstandard2.1/Alpaca.Markets.dll</Left>
+    <Right>lib/netstandard2.1/Alpaca.Markets.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Alpaca.Markets.LatestDataListRequest.#ctor(System.Collections.Generic.IEnumerable{System.String},Alpaca.Markets.CryptoExchange)</Target>
     <Left>lib/netstandard2.1/Alpaca.Markets.dll</Left>
     <Right>lib/netstandard2.1/Alpaca.Markets.dll</Right>
@@ -1613,6 +1641,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
+    <Target>P:Alpaca.Markets.IPortfolioHistory.BaseValue</Target>
+    <Left>lib/net6.0/Alpaca.Markets.dll</Left>
+    <Right>lib/netstandard2.1/Alpaca.Markets.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
     <Target>P:Alpaca.Markets.IAsset.MarginRequirementLong</Target>
     <Left>lib/netstandard2.0/Alpaca.Markets.dll</Left>
     <Right>lib/netstandard2.0/Alpaca.Markets.dll</Right>
@@ -1655,6 +1690,13 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
+    <Target>P:Alpaca.Markets.IPortfolioHistory.BaseValue</Target>
+    <Left>lib/netstandard2.0/Alpaca.Markets.dll</Left>
+    <Right>lib/netstandard2.0/Alpaca.Markets.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
     <Target>P:Alpaca.Markets.IAsset.MarginRequirementLong</Target>
     <Left>lib/netstandard2.1/Alpaca.Markets.dll</Left>
     <Right>lib/netstandard2.1/Alpaca.Markets.dll</Right>
@@ -1691,6 +1733,13 @@
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
     <Target>P:Alpaca.Markets.IOrder.OrderSide</Target>
+    <Left>lib/netstandard2.1/Alpaca.Markets.dll</Left>
+    <Right>lib/netstandard2.1/Alpaca.Markets.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>P:Alpaca.Markets.IPortfolioHistory.BaseValue</Target>
     <Left>lib/netstandard2.1/Alpaca.Markets.dll</Left>
     <Right>lib/netstandard2.1/Alpaca.Markets.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/Alpaca.Markets/CompatibilitySuppressions.xml
+++ b/Alpaca.Markets/CompatibilitySuppressions.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
@@ -1571,6 +1571,20 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
+    <Target>P:Alpaca.Markets.IAsset.MarginRequirementLong</Target>
+    <Left>lib/net6.0/Alpaca.Markets.dll</Left>
+    <Right>lib/netstandard2.1/Alpaca.Markets.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>P:Alpaca.Markets.IAsset.MarginRequirementShort</Target>
+    <Left>lib/net6.0/Alpaca.Markets.dll</Left>
+    <Right>lib/netstandard2.1/Alpaca.Markets.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
     <Target>P:Alpaca.Markets.IEnvironment.AlpacaOptionsStreamingApi</Target>
     <Left>lib/net6.0/Alpaca.Markets.dll</Left>
     <Right>lib/netstandard2.1/Alpaca.Markets.dll</Right>
@@ -1599,6 +1613,20 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
+    <Target>P:Alpaca.Markets.IAsset.MarginRequirementLong</Target>
+    <Left>lib/netstandard2.0/Alpaca.Markets.dll</Left>
+    <Right>lib/netstandard2.0/Alpaca.Markets.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>P:Alpaca.Markets.IAsset.MarginRequirementShort</Target>
+    <Left>lib/netstandard2.0/Alpaca.Markets.dll</Left>
+    <Right>lib/netstandard2.0/Alpaca.Markets.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
     <Target>P:Alpaca.Markets.IEnvironment.AlpacaOptionsStreamingApi</Target>
     <Left>lib/netstandard2.0/Alpaca.Markets.dll</Left>
     <Right>lib/netstandard2.0/Alpaca.Markets.dll</Right>
@@ -1623,6 +1651,20 @@
     <Target>P:Alpaca.Markets.IOrder.OrderSide</Target>
     <Left>lib/netstandard2.0/Alpaca.Markets.dll</Left>
     <Right>lib/netstandard2.0/Alpaca.Markets.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>P:Alpaca.Markets.IAsset.MarginRequirementLong</Target>
+    <Left>lib/netstandard2.1/Alpaca.Markets.dll</Left>
+    <Right>lib/netstandard2.1/Alpaca.Markets.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>P:Alpaca.Markets.IAsset.MarginRequirementShort</Target>
+    <Left>lib/netstandard2.1/Alpaca.Markets.dll</Left>
+    <Right>lib/netstandard2.1/Alpaca.Markets.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>

--- a/Alpaca.Markets/Enums/AssetClass.cs
+++ b/Alpaca.Markets/Enums/AssetClass.cs
@@ -25,5 +25,12 @@ public enum AssetClass
     /// </summary>
     [UsedImplicitly]
     [EnumMember(Value = "us_option")]
-    UsOption
+    UsOption,
+
+    /// <summary>
+    /// Perpetual cryptocurrency asset class.
+    /// </summary>
+    [UsedImplicitly]
+    [EnumMember(Value = "crypto_perp")]
+    CryptoPerpetual
 }

--- a/Alpaca.Markets/Enums/Exchange.cs
+++ b/Alpaca.Markets/Enums/Exchange.cs
@@ -82,5 +82,12 @@ public enum Exchange
     /// </summary>
     [UsedImplicitly]
     [EnumMember(Value = "FTXU")]
-    Crypto
+    Crypto,
+
+    /// <summary>
+    /// Alpaca crypto Exchange.
+    /// </summary>
+    [UsedImplicitly]
+    [EnumMember(Value = "ASCX")]
+    Ascx
 }

--- a/Alpaca.Markets/Enums/MarketDataFeed.cs
+++ b/Alpaca.Markets/Enums/MarketDataFeed.cs
@@ -34,5 +34,19 @@ public enum MarketDataFeed
     /// </summary>
     [UsedImplicitly]
     [EnumMember(Value = "delayed_sip")]
-    DelayedSip
+    DelayedSip,
+
+    /// <summary>
+    /// BOATS feed - Blue Ocean, overnight US trading data.
+    /// </summary>
+    [UsedImplicitly]
+    [EnumMember(Value = "boats")]
+    Boats,
+
+    /// <summary>
+    /// Overnight feed - derived overnight US trading data.
+    /// </summary>
+    [UsedImplicitly]
+    [EnumMember(Value = "overnight")]
+    Overnight
 }

--- a/Alpaca.Markets/Interfaces/IAsset.cs
+++ b/Alpaca.Markets/Interfaces/IAsset.cs
@@ -95,8 +95,20 @@ public interface IAsset
     /// <summary>
     /// Gets the % margin requirement for the asset. This property is valid only for equity assets.
     /// </summary>
-    [UsedImplicitly]
+    [Obsolete("This property is obsolete and will be removed in the next major SDK release. Please use MarginRequirementLong and/or MarginRequirementShort properties instead.", false)]
     Decimal? MaintenanceMarginRequirement { get; }
+
+    /// <summary>
+    /// Gets the % long margin requirement for the asset. This property is valid only for equity assets.
+    /// </summary>
+    [UsedImplicitly]
+    Decimal? MarginRequirementLong { get; }
+
+    /// <summary>
+    /// Gets the % short margin requirement for the asset. This property is valid only for equity assets.
+    /// </summary>
+    [UsedImplicitly]
+    Decimal? MarginRequirementShort { get; }
 
     /// <summary>
     /// Gets the list of asset attributes (unique asset characteristics like PTP order acceptance mode).

--- a/Alpaca.Markets/Interfaces/IPortfolioHistory.cs
+++ b/Alpaca.Markets/Interfaces/IPortfolioHistory.cs
@@ -21,5 +21,5 @@ public interface IPortfolioHistory
     /// Gets base value for this historical view.
     /// </summary>
     [UsedImplicitly]
-    Decimal BaseValue { get; }
+    Decimal? BaseValue { get; }
 }

--- a/Alpaca.Markets/Messages/JsonAsset.cs
+++ b/Alpaca.Markets/Messages/JsonAsset.cs
@@ -51,6 +51,12 @@ internal sealed class JsonAsset : IAsset
     [JsonProperty(PropertyName = "maintenance_margin_requirement", Required = Required.Default)]
     public Decimal? MaintenanceMarginRequirement { get; set;  }
 
+    [JsonProperty(PropertyName = "margin_requirement_long", Required = Required.Default)]
+    public Decimal? MarginRequirementLong { get; set; }
+
+    [JsonProperty(PropertyName = "margin_requirement_short", Required = Required.Default)]
+    public Decimal? MarginRequirementShort { get; set; }
+
     [JsonIgnore]
     public IReadOnlyList<AssetAttributes> Attributes => AttributesList;
 

--- a/Alpaca.Markets/Messages/JsonPortfolioHistory.cs
+++ b/Alpaca.Markets/Messages/JsonPortfolioHistory.cs
@@ -45,8 +45,8 @@ internal sealed class JsonPortfolioHistory : IPortfolioHistory
     [JsonProperty(PropertyName = "timeframe", Required = Required.Always)]
     public TimeFrame TimeFrame { get; set; }
 
-    [JsonProperty(PropertyName = "base_value", Required = Required.Always)]
-    public Decimal BaseValue { get; set; }
+    [JsonProperty(PropertyName = "base_value", Required = Required.Default)]
+    public Decimal? BaseValue { get; set; }
 
     [OnDeserialized]
     [UsedImplicitly]

--- a/Alpaca.Markets/PublicAPI.Shipped.txt
+++ b/Alpaca.Markets/PublicAPI.Shipped.txt
@@ -127,7 +127,9 @@ Alpaca.Markets.AssetAttributes.Ipo = 3 -> Alpaca.Markets.AssetAttributes
 Alpaca.Markets.AssetAttributes.Unknown = 0 -> Alpaca.Markets.AssetAttributes
 Alpaca.Markets.AssetClass
 Alpaca.Markets.AssetClass.Crypto = 1 -> Alpaca.Markets.AssetClass
+Alpaca.Markets.AssetClass.CryptoPerpetual = 3 -> Alpaca.Markets.AssetClass
 Alpaca.Markets.AssetClass.UsEquity = 0 -> Alpaca.Markets.AssetClass
+Alpaca.Markets.AssetClass.UsOption = 2 -> Alpaca.Markets.AssetClass
 Alpaca.Markets.AssetsRequest
 Alpaca.Markets.AssetsRequest.Attributes.get -> System.Collections.Generic.ISet<Alpaca.Markets.AssetAttributes>!
 Alpaca.Markets.AssetsRequest.AssetClass.get -> Alpaca.Markets.AssetClass?
@@ -145,7 +147,6 @@ Alpaca.Markets.AuthStatus
 Alpaca.Markets.AuthStatus.Authorized = 0 -> Alpaca.Markets.AuthStatus
 Alpaca.Markets.AuthStatus.TooManyConnections = 2 -> Alpaca.Markets.AuthStatus
 Alpaca.Markets.AuthStatus.Unauthorized = 1 -> Alpaca.Markets.AuthStatus
-Alpaca.Markets.AssetClass.UsOption = 2 -> Alpaca.Markets.AssetClass
 Alpaca.Markets.BarTimeFrame
 Alpaca.Markets.BarTimeFrame.BarTimeFrame() -> void
 Alpaca.Markets.BarTimeFrame.BarTimeFrame(int value, Alpaca.Markets.BarTimeFrameUnit unit) -> void
@@ -259,6 +260,7 @@ Alpaca.Markets.Environments
 Alpaca.Markets.Exchange
 Alpaca.Markets.Exchange.Amex = 6 -> Alpaca.Markets.Exchange
 Alpaca.Markets.Exchange.Arca = 7 -> Alpaca.Markets.Exchange
+Alpaca.Markets.Exchange.Ascx = 11 -> Alpaca.Markets.Exchange
 Alpaca.Markets.Exchange.Bats = 5 -> Alpaca.Markets.Exchange
 Alpaca.Markets.Exchange.Crypto = 10 -> Alpaca.Markets.Exchange
 Alpaca.Markets.Exchange.Iex = 8 -> Alpaca.Markets.Exchange
@@ -561,6 +563,8 @@ Alpaca.Markets.IAsset.Fractionable.get -> bool
 Alpaca.Markets.IAsset.IsTradable.get -> bool
 Alpaca.Markets.IAsset.MaintenanceMarginRequirement.get -> decimal?
 Alpaca.Markets.IAsset.Marginable.get -> bool
+Alpaca.Markets.IAsset.MarginRequirementLong.get -> decimal?
+Alpaca.Markets.IAsset.MarginRequirementShort.get -> decimal?
 Alpaca.Markets.IAsset.MinOrderSize.get -> decimal?
 Alpaca.Markets.IAsset.MinTradeIncrement.get -> decimal?
 Alpaca.Markets.IAsset.Name.get -> string!
@@ -1059,9 +1063,11 @@ Alpaca.Markets.ListOrdersRequest.WithInterval(Alpaca.Markets.Interval<System.Dat
 Alpaca.Markets.ListOrdersRequest.WithSymbol(string! symbol) -> Alpaca.Markets.ListOrdersRequest!
 Alpaca.Markets.ListOrdersRequest.WithSymbols(System.Collections.Generic.IEnumerable<string!>! symbols) -> Alpaca.Markets.ListOrdersRequest!
 Alpaca.Markets.MarketDataFeed
+Alpaca.Markets.MarketDataFeed.Boats = 4 -> Alpaca.Markets.MarketDataFeed
 Alpaca.Markets.MarketDataFeed.DelayedSip = 3 -> Alpaca.Markets.MarketDataFeed
 Alpaca.Markets.MarketDataFeed.Iex = 0 -> Alpaca.Markets.MarketDataFeed
 Alpaca.Markets.MarketDataFeed.Otc = 2 -> Alpaca.Markets.MarketDataFeed
+Alpaca.Markets.MarketDataFeed.Overnight = 5 -> Alpaca.Markets.MarketDataFeed
 Alpaca.Markets.MarketDataFeed.Sip = 1 -> Alpaca.Markets.MarketDataFeed
 Alpaca.Markets.MarketOrder
 Alpaca.Markets.MultiLegOrder

--- a/Alpaca.Markets/PublicAPI.Shipped.txt
+++ b/Alpaca.Markets/PublicAPI.Shipped.txt
@@ -809,7 +809,7 @@ Alpaca.Markets.IPage<TItems>.Items.get -> System.Collections.Generic.IReadOnlyLi
 Alpaca.Markets.IPage<TItems>.NextPageToken.get -> string?
 Alpaca.Markets.IPage<TItems>.Symbol.get -> string!
 Alpaca.Markets.IPortfolioHistory
-Alpaca.Markets.IPortfolioHistory.BaseValue.get -> decimal
+Alpaca.Markets.IPortfolioHistory.BaseValue.get -> decimal?
 Alpaca.Markets.IPortfolioHistory.Items.get -> System.Collections.Generic.IReadOnlyList<Alpaca.Markets.IPortfolioHistoryItem!>!
 Alpaca.Markets.IPortfolioHistory.TimeFrame.get -> Alpaca.Markets.TimeFrame
 Alpaca.Markets.IPortfolioHistoryItem

--- a/Alpaca.Markets/PublicAPI.Unshipped.txt
+++ b/Alpaca.Markets/PublicAPI.Unshipped.txt
@@ -1,3 +1,7 @@
 ﻿#nullable enable
+Alpaca.Markets.AssetClass.CryptoPerpetual = 3 -> Alpaca.Markets.AssetClass
+Alpaca.Markets.Exchange.Ascx = 11 -> Alpaca.Markets.Exchange
 Alpaca.Markets.IAsset.MarginRequirementLong.get -> decimal?
 Alpaca.Markets.IAsset.MarginRequirementShort.get -> decimal?
+Alpaca.Markets.MarketDataFeed.Boats = 4 -> Alpaca.Markets.MarketDataFeed
+Alpaca.Markets.MarketDataFeed.Overnight = 5 -> Alpaca.Markets.MarketDataFeed

--- a/Alpaca.Markets/PublicAPI.Unshipped.txt
+++ b/Alpaca.Markets/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 ﻿#nullable enable
+Alpaca.Markets.IAsset.MarginRequirementLong.get -> decimal?
+Alpaca.Markets.IAsset.MarginRequirementShort.get -> decimal?

--- a/Alpaca.Markets/PublicAPI.Unshipped.txt
+++ b/Alpaca.Markets/PublicAPI.Unshipped.txt
@@ -1,7 +1,1 @@
 ﻿#nullable enable
-Alpaca.Markets.AssetClass.CryptoPerpetual = 3 -> Alpaca.Markets.AssetClass
-Alpaca.Markets.Exchange.Ascx = 11 -> Alpaca.Markets.Exchange
-Alpaca.Markets.IAsset.MarginRequirementLong.get -> decimal?
-Alpaca.Markets.IAsset.MarginRequirementShort.get -> decimal?
-Alpaca.Markets.MarketDataFeed.Boats = 4 -> Alpaca.Markets.MarketDataFeed
-Alpaca.Markets.MarketDataFeed.Overnight = 5 -> Alpaca.Markets.MarketDataFeed


### PR DESCRIPTION
- The new `MarginRequirementLong` and `MarginRequirementShort` properties were added to the `IAsset` interface.
- The old `MaintenanceMarginRequirement` property of the `IAsset` interface is marked as obsolete.
- The new `Boats` and `Overnight` values were added to the `MarketDataFeed` enumeration.
- The new `CryptoPerpetual` value was added to the `AssetClass` enumeration.
- The `BaseValue` property in `IPortfolioHistory` was changed to be nullable.
- The new `Ascx` value was added to the `Exchange` enumeration.
