### PR TITLE
Fix: incorrect options streaming URI path construction

### DIFF
--- a/Alpaca.Markets/Parameters/AlpacaOptionsStreamingClientConfiguration.cs
+++ b/Alpaca.Markets/Parameters/AlpacaOptionsStreamingClientConfiguration.cs
@@ -60,6 +60,6 @@ public sealed class AlpacaOptionsStreamingClientConfiguration : StreamingClientC
         // Options streaming API uses format: wss://stream.data.alpaca.markets/v1beta1/{feed}
         // where {feed} is either "indicative" or "opra"
         var feedValue = Feed == OptionsFeed.Opra ? "opra" : "indicative";
-        return new Uri(baseUrl, $"v1beta1/{feedValue}");
+        return new Uri(baseUrl, feedValue);
     }
 }


### PR DESCRIPTION
## Description
This PR fixes the incorrect construction of the options streaming WebSocket endpoint URI.
Previously, the URI appended an extra path segment (`v1beta1/{feed}`), which resulted in an invalid connection URL.
The fix removes the unnecessary segment, ensuring the correct format:
`wss://stream.data.alpaca.markets/{feed}`
where {`feed`} is either `indicative` or `opra`.

<img width="1367" height="586" alt="image" src="https://github.com/user-attachments/assets/08ecef77-21e9-47d3-9652-77e9ced22b21" />

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Verified that the WebSocket successfully connects to both indicative and opra feeds.
- Reviewed endpoint construction logic to ensure URI composition matches Alpaca API documentation.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
