### PR TITLE
feat: add allium behavioral specs

### DIFF
--- a/.allium/trading-api-client.allium
+++ b/.allium/trading-api-client.allium
@@ -1,0 +1,598 @@
+-- allium: 3
+-- trading-api-client.allium
+
+-- Scope: Alpaca Markets .NET SDK — trading operations and market data
+-- Includes: Account, Asset, Order lifecycle, Position, WatchList,
+--           PortfolioHistory, TradeUpdate, AccountActivity,
+--           OptionContract, Bar, Quote, Clock, IntervalCalendar
+-- Excludes:
+--   - Generated PublicAPI surface snapshot files (api analyzer snapshots)
+--   - HTTP/WebSocket transport implementation details
+--   - Streaming subscription management (connection, subscription registry)
+
+------------------------------------------------------------
+-- Enumerations
+------------------------------------------------------------
+
+enum OrderStatus {
+    accepted | pending_new | new | partially_filled | filled |
+    done_for_day | canceled | pending_cancel | stopped | rejected |
+    suspended | expired | replaced | pending_replace | replace_rejected |
+    calculated | accepted_for_bidding | held
+}
+
+enum OrderSide { buy | sell }
+
+enum OrderType { market | limit | stop | stop_limit | trailing_stop }
+
+enum TimeInForce { day | gtc | opg | ioc | fok | cls }
+
+enum OrderClass { simple | bracket | oco | oto | multi_leg_options }
+
+enum PositionSide { long | short }
+
+enum AssetStatus { active | inactive | delisted }
+
+enum AssetClass { us_equity | crypto | us_option | crypto_perpetual }
+
+enum AccountStatus {
+    onboarding | submission_failed | submitted | account_updated |
+    approval_pending | active | rejected | disabled | disable_pending |
+    approved | inactive | edited | action_required | account_closed | paper_only
+}
+
+enum TradeEventType {
+    new | partial_fill | fill | done_for_day | canceled | pending_cancel |
+    stopped | rejected | suspended | pending_new | calculated | expired |
+    order_cancel_rejected | replaced | pending_replace | replace_rejected |
+    partially_filled | accepted | held | pending_review
+}
+
+enum AccountActivityType {
+    fill | cash_deposit | cash_withdrawal | dividend | dividend_tax |
+    merger_acquisition | name_change | symbol_change | stock_spinoff |
+    stock_split | option_assignment | option_expiration | option_exercise |
+    option_trade | fee | crypto_fee | acats | journal_entry | interest |
+    miscellaneous | pass_thru_charge | pass_thru_rebate | unknown
+}
+
+enum OptionType { call | put }
+
+enum OptionStyle { american | european }
+
+enum OptionsTradingLevel { disabled | covered_call_cash_secured_put | long_call_put }
+
+enum BarTimeFrameUnit { minute | hour | day | week | month }
+
+------------------------------------------------------------
+-- Value Types
+------------------------------------------------------------
+
+value OrderQuantity {
+    is_notional: Boolean
+    amount: Decimal
+}
+
+value BarTimeFrame {
+    amount: Integer
+    unit: BarTimeFrameUnit
+}
+
+-- One interval's snapshot within a PortfolioHistory response
+value PortfolioHistoryItem {
+    timestamp: Timestamp
+    equity: Decimal?
+    profit_loss: Decimal?
+    profit_loss_percentage: Decimal?
+}
+
+------------------------------------------------------------
+-- Entities and Variants
+------------------------------------------------------------
+
+entity Asset {
+    asset_id: String
+    symbol: String
+    name: String
+    asset_class: AssetClass
+    exchange: String
+    status: AssetStatus
+    is_tradable: Boolean
+    marginable: Boolean
+    shortable: Boolean
+    easy_to_borrow: Boolean
+    fractionable: Boolean
+    min_order_size: Decimal?
+    min_trade_increment: Decimal?
+    price_increment: Decimal?
+    margin_requirement_long: Decimal?
+    margin_requirement_short: Decimal?
+}
+
+entity Account {
+    account_id: String
+    account_number: String
+    status: AccountStatus
+    created_at: Timestamp
+    tradable_cash: Decimal
+    equity: Decimal
+    last_equity: Decimal
+    buying_power: Decimal
+    day_trading_buying_power: Decimal
+    regulation_buying_power: Decimal
+    non_marginable_buying_power: Decimal
+    options_buying_power: Decimal?
+    long_market_value: Decimal
+    short_market_value: Decimal
+    cost_basis: Decimal
+    initial_margin: Decimal
+    maintenance_margin: Decimal
+    last_maintenance_margin: Decimal
+    sma: Decimal
+    is_day_pattern_trader: Boolean
+    shorting_enabled: Boolean
+    trade_suspended_by_user: Boolean
+    is_trading_blocked: Boolean
+    is_transfers_blocked: Boolean
+    options_trading_level: OptionsTradingLevel?
+    options_approved_level: OptionsTradingLevel?
+    day_trade_count: Integer
+    multiplier: Integer
+    accrued_fees: Decimal
+    pending_transfer_in: Decimal?
+    pending_transfer_out: Decimal?
+}
+
+entity AccountConfiguration {
+    account: Account
+    dtbp_check: String
+    no_shorting: Boolean
+    suspend_trade: Boolean
+    trade_confirm_email: String
+    fractional_trading: Boolean?
+    max_margin_multiplier: Integer?
+}
+
+entity Order {
+    account: Account
+    order_id: String
+    client_order_id: String?
+    status: OrderStatus
+    asset: Asset
+    side: OrderSide
+    order_type: OrderType
+    time_in_force: TimeInForce
+    order_class: OrderClass
+    quantity: OrderQuantity?
+    filled_quantity: Decimal
+    average_fill_price: Decimal?
+    limit_price: Decimal?
+    stop_price: Decimal?
+    trail_offset_dollars: Decimal?
+    trail_offset_percent: Decimal?
+    high_water_mark: Decimal?
+    extended_hours: Boolean
+    created_at: Timestamp
+    submitted_at: Timestamp?
+    filled_at: Timestamp?
+    cancelled_at: Timestamp?
+    expired_at: Timestamp?
+    failed_at: Timestamp?
+    replaced_at: Timestamp?
+    replaced_by: Order?
+    replaces: Order?
+    legs: List<Order>
+
+    is_open: status in {accepted, pending_new, new, partially_filled, held, pending_cancel, pending_replace}
+    is_terminal: status in {filled, canceled, rejected, replaced, expired, done_for_day, stopped, suspended, replace_rejected}
+}
+
+entity Position {
+    account: Account
+    asset: Asset
+    side: PositionSide
+    quantity: Decimal
+    available_quantity: Decimal
+    average_entry_price: Decimal
+    cost_basis: Decimal
+    market_value: Decimal
+    current_price: Decimal
+    last_price: Decimal
+    asset_change_percent: Decimal
+    unrealized_profit_loss: Decimal
+    unrealized_profit_loss_percent: Decimal
+    intraday_unrealized_profit_loss: Decimal
+
+    invariant QuantityPositive {
+        quantity > 0
+    }
+
+    invariant AvailableWithinTotal {
+        available_quantity <= quantity
+    }
+}
+
+entity WatchList {
+    account: Account
+    watch_list_id: String
+    name: String
+    created_at: Timestamp
+    updated_at: Timestamp
+    assets: Set<Asset>
+}
+
+entity TradeUpdate {
+    event_type: TradeEventType
+    execution_id: String?
+    order: Order
+    price: Decimal?
+    trade_quantity: Decimal?
+    position_quantity: Decimal?
+    timestamp: Timestamp
+}
+
+entity AccountActivity {
+    activity_id: String
+    activity_type: AccountActivityType
+    activity_at: Timestamp
+    symbol: String?
+    net_amount: Decimal?
+    per_share_amount: Decimal?
+    quantity: Decimal?
+    cumulative_quantity: Decimal?
+    leaves_quantity: Decimal?
+    price: Decimal?
+    side: OrderSide?
+    transaction_time: Timestamp?
+    trade_event: TradeEventType?
+    order_id: String?
+}
+
+entity PortfolioHistory {
+    -- One item per time interval; equity and P&L may be absent for illiquid periods
+    items: List<PortfolioHistoryItem>
+    base_value: Decimal?
+    time_frame: BarTimeFrame
+}
+
+entity OptionContract {
+    contract_id: String
+    symbol: String
+    underlying: Asset
+    expiration_date: Timestamp
+    option_type: OptionType
+    option_style: OptionStyle
+    strike_price: Decimal
+    status: active | expired
+    multiplier: Decimal
+}
+
+entity Bar {
+    symbol: String
+    time: Timestamp
+    open: Decimal
+    high: Decimal
+    low: Decimal
+    close: Decimal
+    volume: Decimal
+    vwap: Decimal
+    trade_count: Integer
+}
+
+entity Quote {
+    symbol: String
+    timestamp: Timestamp
+    bid_price: Decimal
+    ask_price: Decimal
+    bid_size: Decimal
+    ask_size: Decimal
+    bid_exchange: String?
+    ask_exchange: String?
+}
+
+entity Clock {
+    timestamp: Timestamp
+    is_open: Boolean
+    next_open: Timestamp
+    next_close: Timestamp
+}
+
+entity IntervalCalendar {
+    date: Timestamp
+    session_open: Timestamp
+    session_close: Timestamp
+}
+
+------------------------------------------------------------
+-- Rules
+------------------------------------------------------------
+
+-- Order Placement
+
+rule PlaceOrder {
+    when: PlaceOrder(account, asset, side, order_type, time_in_force, quantity?, order_class?, extended_hours?)
+
+    requires: account.status = active
+    requires: not account.is_trading_blocked
+    requires: asset.status = active
+    requires: asset.is_tradable
+    requires: side = sell implies asset.shortable
+
+    ensures: Order.created(
+        account: account,
+        status: accepted,
+        asset: asset,
+        side: side,
+        order_type: order_type,
+        time_in_force: time_in_force,
+        quantity: quantity,
+        filled_quantity: 0,
+        order_class: order_class ?? simple,
+        extended_hours: extended_hours ?? false,
+        created_at: now
+    )
+}
+
+-- Order Cancellation
+
+rule RequestOrderCancellation {
+    when: RequestOrderCancellation(order)
+
+    requires: order.is_open
+
+    ensures: order.status = pending_cancel
+}
+
+rule OrderCancelConfirmed {
+    when: OrderCancelConfirmed(order)
+
+    requires: order.status = pending_cancel
+
+    ensures: order.status = canceled
+    ensures: order.cancelled_at = now
+    ensures: TradeUpdate.created(
+        event_type: canceled,
+        order: order,
+        timestamp: now
+    )
+}
+
+rule OrderCancelRejected {
+    when: OrderCancelRejected(order)
+
+    requires: order.status = pending_cancel
+
+    ensures: order.status = new
+    ensures: TradeUpdate.created(
+        event_type: order_cancel_rejected,
+        order: order,
+        timestamp: now
+    )
+}
+
+rule CancelAllOrders {
+    when: CancelAllOrders(target_account)
+
+    requires: target_account.status = active
+    for order in Orders where account = target_account and is_open:
+        ensures: order.status = pending_cancel
+}
+
+-- Order Replacement
+
+rule RequestOrderReplacement {
+    when: RequestOrderReplacement(order, new_quantity?, new_limit_price?, new_stop_price?, new_time_in_force?)
+
+    requires: order.status in {new, partially_filled, pending_new, accepted, held}
+
+    ensures: order.status = pending_replace
+}
+
+rule OrderReplaceConfirmed {
+    when: OrderReplaceConfirmed(original_order, replacement)
+
+    requires: original_order.status = pending_replace
+
+    ensures: original_order.status = replaced
+    ensures: original_order.replaced_at = now
+    ensures: original_order.replaced_by = replacement
+    ensures: replacement.replaces = original_order
+    ensures: TradeUpdate.created(
+        event_type: replaced,
+        order: original_order,
+        timestamp: now
+    )
+}
+
+rule OrderReplaceRejected {
+    when: OrderReplaceRejected(order)
+
+    requires: order.status = pending_replace
+
+    ensures: order.status = new
+    ensures: TradeUpdate.created(
+        event_type: replace_rejected,
+        order: order,
+        timestamp: now
+    )
+}
+
+-- Order Fills
+
+rule OrderPartialFill {
+    when: OrderPartialFill(order, execution_id, fill_price, fill_quantity)
+
+    requires: order.status in {new, partially_filled, pending_new, accepted}
+
+    ensures: order.status = partially_filled
+    ensures: order.filled_quantity = order.filled_quantity + fill_quantity
+    ensures: order.average_fill_price = weighted_average_fill_price(order.average_fill_price, order.filled_quantity, fill_price, fill_quantity)
+    ensures: TradeUpdate.created(
+        event_type: partial_fill,
+        execution_id: execution_id,
+        order: order,
+        price: fill_price,
+        trade_quantity: fill_quantity,
+        timestamp: now
+    )
+}
+
+rule OrderFilled {
+    when: OrderFilled(order, execution_id, fill_price, fill_quantity)
+
+    requires: order.status in {new, partially_filled, pending_new, accepted}
+
+    ensures: order.status = filled
+    ensures: order.filled_quantity = order.filled_quantity + fill_quantity
+    ensures: order.filled_at = now
+    ensures: order.average_fill_price = weighted_average_fill_price(order.average_fill_price, order.filled_quantity, fill_price, fill_quantity)
+    ensures: TradeUpdate.created(
+        event_type: fill,
+        execution_id: execution_id,
+        order: order,
+        price: fill_price,
+        trade_quantity: fill_quantity,
+        timestamp: now
+    )
+}
+
+-- Market Session Expiration
+
+rule DayOrdersExpiredAtClose {
+    when: MarketClosed()
+    for order in Orders where time_in_force = day and is_open:
+        ensures:
+            order.status = done_for_day
+            TradeUpdate.created(
+                event_type: done_for_day,
+                order: order,
+                timestamp: now
+            )
+}
+
+-- Watch Lists
+
+rule CreateWatchList {
+    when: CreateWatchList(account, name, initial_assets?)
+
+    ensures: WatchList.created(
+        account: account,
+        name: name,
+        created_at: now,
+        updated_at: now,
+        assets: initial_assets ?? {}
+    )
+}
+
+rule AddAssetToWatchList {
+    when: AddAssetToWatchList(watch_list, asset)
+
+    requires: asset not in watch_list.assets
+    requires: asset.status = active
+
+    ensures: watch_list.assets.add(asset)
+    ensures: watch_list.updated_at = now
+}
+
+rule RemoveAssetFromWatchList {
+    when: RemoveAssetFromWatchList(watch_list, asset)
+
+    requires: asset in watch_list.assets
+
+    ensures: watch_list.assets.remove(asset)
+    ensures: watch_list.updated_at = now
+}
+
+rule DeleteWatchList {
+    when: DeleteWatchList(watch_list)
+
+    ensures: not exists watch_list
+}
+
+-- Positions
+
+rule LiquidatePosition {
+    when: LiquidatePosition(account, asset, percentage?)
+
+    requires: account.status = active
+    requires: not account.is_trading_blocked
+    let position = Position{account, asset}
+    requires: exists position
+
+    ensures: Order.created(
+        account: account,
+        status: accepted,
+        asset: asset,
+        side: sell,
+        order_type: market,
+        order_class: simple,
+        time_in_force: day,
+        filled_quantity: 0,
+        extended_hours: false,
+        created_at: now
+    )
+}
+
+rule LiquidateAllPositions {
+    when: LiquidateAllPositions(target_account)
+
+    requires: target_account.status = active
+    requires: not target_account.is_trading_blocked
+    for position in Positions where account = target_account:
+        ensures: Order.created(
+            account: target_account,
+            status: accepted,
+            asset: position.asset,
+            side: sell,
+            order_type: market,
+            order_class: simple,
+            time_in_force: day,
+            filled_quantity: 0,
+            extended_hours: false,
+            created_at: now
+        )
+}
+
+-- Options Exercise
+
+rule ExerciseOptionPosition {
+    when: ExerciseOptionPosition(account, contract)
+
+    requires: account.status = active
+    requires: contract.option_style = american
+    requires: contract.status = active
+
+    ensures: AccountActivity.created(
+        activity_type: option_exercise,
+        activity_at: now,
+        symbol: contract.symbol,
+        net_amount: contract.strike_price * contract.multiplier,
+        quantity: contract.multiplier
+    )
+}
+
+-- Account Configuration
+
+rule UpdateAccountConfiguration {
+    when: UpdateAccountConfiguration(account, no_shorting, suspend_trade, trade_confirm_email)
+
+    requires: account.status = active
+    let config = AccountConfiguration{account}
+    requires: exists config
+
+    ensures:
+        config.no_shorting = no_shorting
+        config.suspend_trade = suspend_trade
+        config.trade_confirm_email = trade_confirm_email
+}
+
+------------------------------------------------------------
+-- Invariants
+------------------------------------------------------------
+
+invariant UniqueClientOrderId {
+    for a in Orders:
+        for b in Orders:
+            a != b and a.client_order_id != null and b.client_order_id != null
+                implies a.client_order_id != b.client_order_id
+}

--- a/.allium/trading-api-client.allium
+++ b/.allium/trading-api-client.allium
@@ -17,7 +17,7 @@
 enum OrderStatus {
     accepted | pending_new | new | partially_filled | filled |
     done_for_day | canceled | pending_cancel | stopped | rejected |
-    suspended | expired | replaced | pending_replace | replace_rejected |
+    suspended | expired | replaced | pending_replace |
     calculated | accepted_for_bidding | held
 }
 
@@ -49,11 +49,12 @@ enum TradeEventType {
 }
 
 enum AccountActivityType {
-    fill | cash_deposit | cash_withdrawal | dividend | dividend_tax |
+    fill | cash_deposit | cash_withdrawal | dividend |
     merger_acquisition | name_change | symbol_change | stock_spinoff |
     stock_split | option_assignment | option_expiration | option_exercise |
-    option_trade | fee | crypto_fee | acats | journal_entry | interest |
-    miscellaneous | pass_thru_charge | pass_thru_rebate | unknown
+    option_trade | fee_in_usd | crypto_fee | acat_cash | acat_securities |
+    journal_entry | interest | miscellaneous | pass_thru_charge |
+    pass_thru_rebate | unknown
 }
 
 enum OptionType { call | put }
@@ -124,19 +125,16 @@ entity Account {
     options_buying_power: Decimal?
     long_market_value: Decimal
     short_market_value: Decimal
-    cost_basis: Decimal
     initial_margin: Decimal
     maintenance_margin: Decimal
     last_maintenance_margin: Decimal
     sma: Decimal
-    is_day_pattern_trader: Boolean
     shorting_enabled: Boolean
     trade_suspended_by_user: Boolean
     is_trading_blocked: Boolean
     is_transfers_blocked: Boolean
     options_trading_level: OptionsTradingLevel?
     options_approved_level: OptionsTradingLevel?
-    day_trade_count: Integer
     multiplier: Integer
     accrued_fees: Decimal
     pending_transfer_in: Decimal?
@@ -149,8 +147,7 @@ entity AccountConfiguration {
     no_shorting: Boolean
     suspend_trade: Boolean
     trade_confirm_email: String
-    fractional_trading: Boolean?
-    max_margin_multiplier: Integer?
+    max_options_trading_level: OptionsTradingLevel?
 }
 
 entity Order {
@@ -184,7 +181,7 @@ entity Order {
     legs: List<Order>
 
     is_open: status in {accepted, pending_new, new, partially_filled, held, pending_cancel, pending_replace}
-    is_terminal: status in {filled, canceled, rejected, replaced, expired, done_for_day, stopped, suspended, replace_rejected}
+    is_terminal: status in {filled, canceled, rejected, replaced, expired, done_for_day, stopped, suspended}
 }
 
 entity Position {
@@ -203,12 +200,13 @@ entity Position {
     unrealized_profit_loss_percent: Decimal
     intraday_unrealized_profit_loss: Decimal
 
-    invariant QuantityPositive {
-        quantity > 0
+    -- Quantities are signed: short positions carry negative quantity
+    invariant QuantitySignMatchesSide {
+        (side = long implies quantity > 0) and (side = short implies quantity < 0)
     }
 
     invariant AvailableWithinTotal {
-        available_quantity <= quantity
+        (side = long implies available_quantity <= quantity) and (side = short implies available_quantity >= quantity)
     }
 }
 
@@ -263,8 +261,8 @@ entity OptionContract {
     option_type: OptionType
     option_style: OptionStyle
     strike_price: Decimal
-    status: active | expired
-    multiplier: Decimal
+    status: AssetStatus
+    size: Decimal
 }
 
 entity Bar {
@@ -435,6 +433,12 @@ rule OrderPartialFill {
         trade_quantity: fill_quantity,
         timestamp: now
     )
+
+    @guidance
+        -- weighted_average_fill_price is a black-box computation: the
+        -- quantity-weighted average of all execution prices so far, i.e. the
+        -- prior average_fill_price weighted by the previously filled quantity
+        -- combined with fill_price weighted by fill_quantity.
 }
 
 rule OrderFilled {
@@ -454,6 +458,11 @@ rule OrderFilled {
         trade_quantity: fill_quantity,
         timestamp: now
     )
+
+    @guidance
+        -- weighted_average_fill_price is the same black-box computation as in
+        -- OrderPartialFill: the quantity-weighted average of all execution
+        -- prices across every partial fill plus this final fill.
 }
 
 -- Market Session Expiration
@@ -566,8 +575,8 @@ rule ExerciseOptionPosition {
         activity_type: option_exercise,
         activity_at: now,
         symbol: contract.symbol,
-        net_amount: contract.strike_price * contract.multiplier,
-        quantity: contract.multiplier
+        net_amount: contract.strike_price * contract.size,
+        quantity: contract.size
     )
 }
 
@@ -577,13 +586,13 @@ rule UpdateAccountConfiguration {
     when: UpdateAccountConfiguration(account, no_shorting, suspend_trade, trade_confirm_email)
 
     requires: account.status = active
-    let config = AccountConfiguration{account}
-    requires: exists config
+    let account_config = AccountConfiguration{account}
+    requires: exists account_config
 
     ensures:
-        config.no_shorting = no_shorting
-        config.suspend_trade = suspend_trade
-        config.trade_confirm_email = trade_confirm_email
+        account_config.no_shorting = no_shorting
+        account_config.suspend_trade = suspend_trade
+        account_config.trade_confirm_email = trade_confirm_email
 }
 
 ------------------------------------------------------------

--- a/.github/workflows/allium-check.yml
+++ b/.github/workflows/allium-check.yml
@@ -1,0 +1,81 @@
+name: Allium Check
+
+# Runs `allium check` on every `.allium` file in the repo.
+#
+# Local install:
+#     cargo install --locked --version 3.0.4 allium-cli
+#
+# Toolchain note: allium-cli is a Rust binary and is not bootstrapped through
+# the Makefile's `bin/<name>-<version>` convention (where one exists). The
+# version is single-sourced via the ALLIUM_VERSION env var below.
+
+"on":
+  push:
+    branches: [main]
+    paths:
+      - "**/*.allium"
+      - ".github/workflows/allium-check.yml"
+  pull_request:
+    paths:
+      - "**/*.allium"
+      - ".github/workflows/allium-check.yml"
+
+permissions:
+  contents: read
+
+env:
+  ALLIUM_VERSION: "3.0.4"
+  # Opt in to Node 24 runtime for actions; Node 20 will be removed 2026-09-16.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache allium-cli binary
+        id: cache-allium
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/allium
+          key: allium-cli-${{ env.ALLIUM_VERSION }}-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Install Rust toolchain
+        if: steps.cache-allium.outputs.cache-hit != 'true'
+        # Pinned SHA for `stable` branch — dtolnay/rust-toolchain uses
+        # branches (not tags) for channel pinning, so we pin the commit
+        # instead. Bump when refreshing the toolchain.
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Install allium-cli
+        if: steps.cache-allium.outputs.cache-hit != 'true'
+        run: cargo install --locked --version ${{ env.ALLIUM_VERSION }} allium-cli
+
+      - name: Run allium check
+        # `-e` is GHA's default, but `allium check` exits non-zero on any
+        # warning — we only want to fail CI on actual errors. Disable
+        # errexit and gate on the parsed summary line.
+        shell: bash
+        run: |
+          set +e
+          set -uo pipefail
+          FILES=$(find . -type f -name "*.allium" -not -path "./.git/*" | sort)
+          if [ -z "$FILES" ]; then
+            echo "No .allium files found; nothing to check."
+            exit 0
+          fi
+          echo "Checking:"
+          echo "$FILES" | sed 's/^/  /'
+          allium check $FILES 2>&1 | tee allium.log
+          ERRORS=$(grep -oE '[0-9]+ error\(s\)' allium.log | tail -1 | awk '{print $1}')
+          if [ -z "$ERRORS" ]; then
+            echo "::error::could not parse allium check summary"
+            exit 1
+          fi
+          if [ "$ERRORS" -gt 0 ]; then
+            echo "::error::allium check reported $ERRORS error(s)"
+            exit 1
+          fi
+          echo "OK — 0 errors."

--- a/.github/workflows/allium-check.yml
+++ b/.github/workflows/allium-check.yml
@@ -54,28 +54,71 @@ jobs:
         run: cargo install --locked --version ${{ env.ALLIUM_VERSION }} allium-cli
 
       - name: Run allium check
-        # `-e` is GHA's default, but `allium check` exits non-zero on any
-        # warning — we only want to fail CI on actual errors. Disable
-        # errexit and gate on the parsed summary line.
+        # Gate on DIAGNOSTIC SEVERITY, not on the process exit code and not on
+        # a grepped summary line.
+        #
+        #  * `allium check --help` documents exit 1 as "One or more errors OR
+        #    WARNINGS were reported", so the exit code cannot express
+        #    "errors only". Specs carry unavoidable warnings
+        #    (externalEntity.missingSourceHint, use.unresolvedPath), so gating
+        #    on it would keep this job red for content-free reasons.
+        #  * The previous gate grepped for an "N error(s)" summary. allium
+        #    3.5.0 and 3.5.3 emit JSON and never print that string, so the job
+        #    failed unconditionally, independent of spec content.
+        #  * allium emits ONE JSON DOCUMENT PER SPEC FILE, concatenated, so the
+        #    stream must be slurped (`jq -s`), not parsed as a single object.
+        #
+        # Older binaries printed a human summary instead of JSON and runner
+        # caches are not uniform, so the legacy format is still accepted. If
+        # NEITHER parses, the job fails loudly: a gate that cannot read its own
+        # input must never report green.
         shell: bash
         run: |
-          set +e
           set -uo pipefail
           FILES=$(find . -type f -name "*.allium" -not -path "./.git/*" | sort)
           if [ -z "$FILES" ]; then
             echo "No .allium files found; nothing to check."
             exit 0
           fi
-          echo "Checking:"
-          echo "$FILES" | sed 's/^/  /'
-          allium check $FILES 2>&1 | tee allium.log
-          ERRORS=$(grep -oE '[0-9]+ error\(s\)' allium.log | tail -1 | awk '{print $1}')
-          if [ -z "$ERRORS" ]; then
-            echo "::error::could not parse allium check summary"
+          echo "Checking:"; echo "$FILES" | sed 's/^/  /'
+          allium --version || true
+
+          set +e
+          allium check $FILES >allium.out 2>allium.err
+          RC=$?
+          set -e
+
+          if [ "$RC" -eq 2 ]; then
+            echo "::error::allium check could not resolve inputs (exit 2)"
+            cat allium.err || true
             exit 1
           fi
+
+          ERRORS=""
+          WARNINGS=""
+          if jq -e -s 'length > 0' allium.out >/dev/null 2>&1; then
+            ERRORS=$(jq -s '[.[].diagnostics[]? | select(.severity=="error")] | length' allium.out)
+            WARNINGS=$(jq -s '[.[].diagnostics[]? | select(.severity=="warning")] | length' allium.out)
+            jq -s -r '.[] | .spec_file as $f | .diagnostics[]?
+                      | select(.severity=="error")
+                      | "::error file=\($f),line=\(.location.line // 0)::\(.code): \(.message)"' \
+                      allium.out || true
+          else
+            ERRORS=$(grep -oE '[0-9]+ error\(s\)' allium.out | tail -1 | awk '{print $1}')
+            WARNINGS=$(grep -oE '[0-9]+ warning\(s\)' allium.out | tail -1 | awk '{print $1}')
+            [ -n "$ERRORS" ] && echo "note: parsed legacy text summary (binary predates JSON output)"
+          fi
+
+          if [ -z "$ERRORS" ]; then
+            echo "::error::allium check output matched neither JSON nor the legacy summary (exit $RC)"
+            head -20 allium.out || true
+            cat allium.err || true
+            exit 1
+          fi
+
+          echo "errors: $ERRORS, warnings: ${WARNINGS:-0} (warnings do not gate)"
           if [ "$ERRORS" -gt 0 ]; then
             echo "::error::allium check reported $ERRORS error(s)"
             exit 1
           fi
-          echo "OK — 0 errors."
+          echo "OK - 0 errors."

--- a/.github/workflows/allium-check.yml
+++ b/.github/workflows/allium-check.yml
@@ -3,7 +3,7 @@ name: Allium Check
 # Runs `allium check` on every `.allium` file in the repo.
 #
 # Local install:
-#     cargo install --locked --version 3.0.4 allium-cli
+#     cargo install --locked --version 3.5.0 allium-cli
 #
 # Toolchain note: allium-cli is a Rust binary and is not bootstrapped through
 # the Makefile's `bin/<name>-<version>` convention (where one exists). The
@@ -24,7 +24,7 @@ permissions:
   contents: read
 
 env:
-  ALLIUM_VERSION: "3.0.4"
+  ALLIUM_VERSION: "3.5.0"
   # Opt in to Node 24 runtime for actions; Node 20 will be removed 2026-09-16.
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 

--- a/.github/workflows/allium-drift.yml
+++ b/.github/workflows/allium-drift.yml
@@ -1,0 +1,38 @@
+name: Allium Drift Check
+
+# Thin caller — the drift check logic lives in alpaca-harness.
+#
+# Runs automatically on every PR update. Posts a drift report as a PR comment.
+# Currently in advisory mode (required_passing: false) — drift findings will not
+# block PRs. Flip to true once specs are trusted.
+#
+# Required secret on this repo (set one — the reusable workflow auto-detects):
+#   ANTHROPIC_API_KEY — claude provider (preferred when both set)
+#   CURSOR_API_KEY    — cursor provider
+#
+# Ref pin policy: alpacahq/alpaca-harness is a first-party internal repo and
+# this caller deliberately tracks its `master` so improvements (e.g. parser
+# fixes, model bumps) reach all callers without per-repo PRs. The repo is
+# org-internal, so all branch writes are gated by the same review process
+# as this repo. If we later need pinned releases, switch to a tag and bump
+# via dependabot.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  allium-drift:
+    uses: alpacahq/alpaca-harness/.github/workflows/ai-allium-drift.yml@master
+    with:
+      pr_num: ${{ github.event.pull_request.number }}
+      head_ref: ${{ github.event.pull_request.head.ref }}
+      target_repo: alpacahq/alpaca-trade-api-csharp
+      required_passing: false
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}


### PR DESCRIPTION
## Behavioral Specifications

Machine-distilled from source code using [allium-spec-distillation](https://github.com/alpacahq/allium-spec-distillation).

### `trading-api-client`

```
Scope: Alpaca Markets .NET SDK — trading operations and market data
Includes: Account, Asset, Order lifecycle, Position, WatchList,
PortfolioHistory, TradeUpdate, AccountActivity,
OptionContract, Bar, Quote, Clock, IntervalCalendar
Excludes:
- Generated PublicAPI surface snapshot files (api analyzer snapshots)
- HTTP/WebSocket transport implementation details
- Streaming subscription management (connection, subscription registry)
```

**Review notes:**
- [minor] `weighted_average_fill_price` is called in OrderPartialFill and OrderFilled `ensures:` expressions but is never defined as a rule or value computation in the spec
- [minor] `OptionContract.status` uses an inline anonymous enum `active | expired` rather than a named enum, inconsistent with all other status fields in the spec

---
🤖 Generated with [allium-spec-distillation](https://github.com/alpacahq/allium-spec-distillation)
---

<!-- ci-gate-fix-note -->
### Added: fix for this PR's own Allium Check gate

This PR introduces `.github/workflows/allium-check.yml`. That workflow's gate was broken, so a commit has been added here to fix it rather than opening a separate PR.

**What was wrong.** The gate ran `allium check` and then grepped its output for an `N error(s)` summary line to decide pass/fail. allium 3.5.0 and 3.5.3 emit JSON and never print that string, so the grep matched nothing, the script hit its own `could not parse allium check summary` branch, and the job failed **unconditionally — independently of spec content**. Every Allium Check run across the org has been red since 2026-07-22 for this reason.

**Why the exit code alone is not the fix.** `allium check --help` documents exit 1 as *"One or more errors **or warnings** were reported"*. Specs carry warnings that cannot be removed (`externalEntity.missingSourceHint`, and `use.unresolvedPath` for shared-library imports, which allium 3.5.x cannot resolve locally at all). Gating on the exit code would keep this job red for reasons unrelated to correctness — which is exactly what the original code comment was trying to avoid.

**What it does now.** Parses the diagnostics and fails only on `severity == "error"`. allium emits one JSON document *per spec file*, concatenated, so the stream is slurped with `jq -s` rather than read as a single object. The older human-readable summary is still accepted as a fallback, because runner caches are not uniform across repos. If neither format parses, the job **fails loudly** — a gate that cannot read its own input must never report green.

**Verified** by running both allium 3.5.0 and 3.5.3 against real specs in this org: 0 errors + warnings → PASS (previously FAIL), specs with real errors → FAIL, unparseable input → FAIL.

- **This branch is 56 commit(s) behind its base.** It still merges cleanly (verified with `git merge-tree`, no merge performed), so the distance alone is not a conflict — it is noted here so a reviewer does not have to work that out.

*The spec content of this PR is unchanged by that commit; it touches only the workflow file.*

---

---

<!-- allium-ci-triage -->
## CI status after the allium gate fix

The `allium check` gate in this repo previously grepped for a `N error(s)` line that allium 3.5.x never emits, so it failed unconditionally. That is fixed on this branch, so the checks below are a real signal for the first time. This note records what still fails and whether this PR caused it.

**This PR's diff:** 3 file(s) — .yml(2) .allium(1).
It changes no source code, no dependency manifest and no container definition. A compile, lint, vulnerability-scan or build failure therefore cannot originate from this diff.

### Failing checks

#### Pre-existing failures, not introduced here

- **`Create Release`** — `##[error]Process completed with exit code 254.`
- **`Analyze (csharp)`** — `##[error]Process completed with exit code 1.`

These run against code this PR does not touch. They should be handled on their own, independently of this branch.
