### PR TITLE
feat: add explicit market data feed selection for the data streaming client

### DIFF
--- a/Alpaca.Markets.Extensions/packages.lock.json
+++ b/Alpaca.Markets.Extensions/packages.lock.json
@@ -1067,9 +1067,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.20, )",
-        "resolved": "8.0.20",
-        "contentHash": "Rhcto2AjGvTO62+/VTmBpumBOmqIGp7nYEbTbmEXkCq4yPGxV8whju3/HsIA/bKyo2+DggaYk5+/8sxb1AbPTw=="
+        "requested": "[8.0.27, )",
+        "resolved": "8.0.27",
+        "contentHash": "rQi9TxifHRnXP7lVRZH05DxD2/XGbJp12q0ozcbrlBlBnyyzssFTH/2vLhtKWUp2CT1qVscTrcYTFiwTyKPKRg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/Alpaca.Markets.Tests/StreamingClientFeedEndpointTest.cs
+++ b/Alpaca.Markets.Tests/StreamingClientFeedEndpointTest.cs
@@ -1,0 +1,105 @@
+using System.Net.WebSockets;
+using Alpaca.Markets.Extensions;
+
+namespace Alpaca.Markets.Tests;
+
+public sealed class StreamingClientFeedEndpointTest
+{
+    private static readonly SecurityKey _key =
+        new SecretKey(Guid.NewGuid().ToString("N"), Guid.NewGuid().ToString("N"));
+
+    [Theory]
+    [InlineData(MarketDataFeed.Iex, "wss://stream.data.alpaca.markets/v2/iex")]
+    [InlineData(MarketDataFeed.Sip, "wss://stream.data.alpaca.markets/v2/sip")]
+    [InlineData(MarketDataFeed.Otc, "wss://stream.data.alpaca.markets/v2/otc")]
+    [InlineData(MarketDataFeed.DelayedSip, "wss://stream.data.alpaca.markets/v2/delayed_sip")]
+    [InlineData(MarketDataFeed.Boats, "wss://stream.data.alpaca.markets/v2/boats")]
+    [InlineData(MarketDataFeed.Overnight, "wss://stream.data.alpaca.markets/v2/overnight")]
+    public async Task DataStreamingClientConnectsToSelectedFeed(
+        MarketDataFeed feed,
+        String expectedUrl)
+    {
+        // The selected feed must override the environment-provided endpoint regardless of environment.
+        var connectedUrl = await captureConnectUrlAsync(
+            Environments.Paper.GetAlpacaDataStreamingClientConfiguration(_key, feed),
+            configuration => configuration.GetClient());
+
+        Assert.Equal(expectedUrl, connectedUrl);
+    }
+
+    [Theory]
+    [ClassData(typeof(EnvironmentTestData))]
+    public async Task DataStreamingClientWithFeedOverridesEnvironment(
+        IEnvironment environment)
+    {
+        var connectedUrl = await captureConnectUrlAsync(
+            environment.GetAlpacaDataStreamingClientConfiguration(_key).WithFeed(MarketDataFeed.Sip),
+            configuration => configuration.GetClient());
+
+        Assert.Equal("wss://stream.data.alpaca.markets/v2/sip", connectedUrl);
+    }
+
+    [Fact]
+    public async Task DataStreamingClientWithoutFeedKeepsLiveEndpoint()
+    {
+        var connectedUrl = await captureConnectUrlAsync(
+            Environments.Live.GetAlpacaDataStreamingClientConfiguration(_key),
+            configuration => configuration.GetClient());
+
+        Assert.Equal("wss://stream.data.alpaca.markets/v2/sip", connectedUrl);
+    }
+
+    [Fact]
+    public async Task DataStreamingClientWithoutFeedKeepsPaperEndpoint()
+    {
+        var connectedUrl = await captureConnectUrlAsync(
+            Environments.Paper.GetAlpacaDataStreamingClientConfiguration(_key),
+            configuration => configuration.GetClient());
+
+        Assert.Equal("wss://stream.data.alpaca.markets/v2/iex", connectedUrl);
+    }
+
+    [Theory]
+    [InlineData(OptionsFeed.Opra, "wss://stream.data.alpaca.markets/v1beta1/opra")]
+    [InlineData(OptionsFeed.Indicative, "wss://stream.data.alpaca.markets/v1beta1/indicative")]
+    public async Task OptionsStreamingClientConnectsToSelectedFeed(
+        OptionsFeed feed,
+        String expectedUrl)
+    {
+        // Regression guard: the v1beta1/{feed} path segment must not be duplicated.
+        var connectedUrl = await captureConnectUrlAsync(
+            Environments.Live.GetAlpacaOptionsStreamingClientConfiguration(_key, feed),
+            configuration => configuration.GetClient());
+
+        Assert.Equal(expectedUrl, connectedUrl);
+    }
+
+    private static async Task<String> captureConnectUrlAsync<TConfiguration>(
+        TConfiguration configuration,
+        Func<TConfiguration, IStreamingClient> factory)
+        where TConfiguration : StreamingClientConfiguration
+    {
+        Uri? connectedUrl = null;
+
+        var webSocket = new Mock<IWebSocket>();
+        webSocket
+            .Setup(socket => socket.ConnectAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
+            .Callback<Uri, CancellationToken>((uri, _) => connectedUrl = uri)
+            .Returns(Task.CompletedTask);
+        // Immediately report a clean close so the background receive loop terminates deterministically.
+        webSocket
+            .SetupGet(socket => socket.CloseStatus)
+            .Returns(WebSocketCloseStatus.NormalClosure);
+        webSocket
+            .Setup(socket => socket.ReceiveAsync(It.IsAny<Memory<Byte>>()))
+            .ReturnsAsync(new ReceiveResult(WebSocketMessageType.Close, true, 0));
+
+        configuration.WebSocketFactory = () => webSocket.Object;
+
+        using var client = factory(configuration);
+        await client.ConnectAsync();
+
+        Assert.NotNull(connectedUrl);
+        return connectedUrl!.AbsoluteUri;
+    }
+}

--- a/Alpaca.Markets/Environment/EnvironmentExtensions.cs
+++ b/Alpaca.Markets/Environment/EnvironmentExtensions.cs
@@ -196,6 +196,46 @@ public static class EnvironmentExtensions
         };
 
     /// <summary>
+    /// Creates the new instance of <see cref="IAlpacaDataStreamingClient"/> interface
+    /// implementation for specific environment provided as <paramref name="environment"/> argument
+    /// using the explicitly selected real-time market data <paramref name="feed"/>.
+    /// </summary>
+    /// <param name="environment">Target environment for new object.</param>
+    /// <param name="securityKey">Alpaca API security key.</param>
+    /// <param name="feed">Real-time market data feed selection (IEX, SIP, etc.).</param>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="environment"/> or <paramref name="securityKey"/> argument is <c>null</c>.
+    /// </exception>
+    /// <returns>The new instance of <see cref="IAlpacaDataStreamingClient"/> interface implementation.</returns>
+    [UsedImplicitly]
+    [CLSCompliant(false)]
+    [ExcludeFromCodeCoverage]
+    public static IAlpacaDataStreamingClient GetAlpacaDataStreamingClient(
+        this IEnvironment environment,
+        SecurityKey securityKey,
+        MarketDataFeed feed) =>
+        new AlpacaDataStreamingClient(environment.GetAlpacaDataStreamingClientConfiguration(securityKey, feed));
+
+    /// <summary>
+    /// Creates new instance of <see cref="AlpacaDataStreamingClientConfiguration"/> for specific
+    /// environment provided as <paramref name="environment"/> argument using the explicitly
+    /// selected real-time market data <paramref name="feed"/>.
+    /// </summary>
+    /// <param name="environment">Target environment for new object.</param>
+    /// <param name="securityKey">Alpaca API security key.</param>
+    /// <param name="feed">Real-time market data feed selection (IEX, SIP, etc.).</param>
+    /// <exception cref="ArgumentNullException">
+    /// The <paramref name="environment"/> or <paramref name="securityKey"/> argument is <c>null</c>.
+    /// </exception>
+    /// <returns>New instance of <see cref="AlpacaDataStreamingClientConfiguration"/> object.</returns>
+    [UsedImplicitly]
+    public static AlpacaDataStreamingClientConfiguration GetAlpacaDataStreamingClientConfiguration(
+        this IEnvironment environment,
+        SecurityKey securityKey,
+        MarketDataFeed feed) =>
+        environment.GetAlpacaDataStreamingClientConfiguration(securityKey).WithFeed(feed);
+
+    /// <summary>
     /// Creates the new instance of <see cref="IAlpacaCryptoStreamingClient"/> interface
     /// implementation for specific environment provided as <paramref name="environment"/> argument.
     /// </summary>

--- a/Alpaca.Markets/Parameters/AlpacaDataStreamingClientConfiguration.cs
+++ b/Alpaca.Markets/Parameters/AlpacaDataStreamingClientConfiguration.cs
@@ -1,4 +1,4 @@
-﻿namespace Alpaca.Markets;
+namespace Alpaca.Markets;
 
 /// <summary>
 /// Configuration parameters object for <see cref="IAlpacaDataStreamingClient"/> instance.
@@ -12,4 +12,41 @@ public sealed class AlpacaDataStreamingClientConfiguration : StreamingClientConf
         : base(Environments.Live.AlpacaDataStreamingApi)
     {
     }
+
+    private AlpacaDataStreamingClientConfiguration(
+        AlpacaDataStreamingClientConfiguration configuration,
+        MarketDataFeed feed)
+        : base(configuration.ApiEndpoint)
+    {
+        SecurityId = configuration.SecurityId;
+        WebSocketFactory = configuration.WebSocketFactory;
+        Feed = feed;
+    }
+
+    /// <summary>
+    /// Gets the real-time market data feed (for example, <see cref="MarketDataFeed.Iex"/> or
+    /// <see cref="MarketDataFeed.Sip"/>) used for the data streaming connection. When this property
+    /// is <c>null</c> the feed encoded in the <see cref="StreamingClientConfiguration.ApiEndpoint"/>
+    /// (provided by the selected <see cref="IEnvironment"/>) is used as-is.
+    /// </summary>
+    [UsedImplicitly]
+    public MarketDataFeed? Feed { get; private set; }
+
+    /// <summary>
+    /// Creates new instance of <see cref="AlpacaDataStreamingClientConfiguration"/> object
+    /// with the updated <see cref="Feed"/> value.
+    /// </summary>
+    /// <param name="feed">Real-time market data feed selection (IEX, SIP, etc.).</param>
+    /// <returns>The new instance of the <see cref="AlpacaDataStreamingClientConfiguration"/> object.</returns>
+    [UsedImplicitly]
+    public AlpacaDataStreamingClientConfiguration WithFeed(
+        MarketDataFeed feed) =>
+        new(this, feed);
+
+    internal override Uri GetApiEndpoint() =>
+        Feed.HasValue
+            // Stock data streaming API uses the format wss://stream.data.alpaca.markets/v2/{feed}
+            // where {feed} is one of "iex", "sip", "delayed_sip", "boats" or "overnight".
+            ? new UriBuilder(ApiEndpoint) { Path = $"v2/{Feed.Value.ToEnumString()}" }.Uri
+            : base.GetApiEndpoint();
 }

--- a/Alpaca.Markets/Parameters/AlpacaOptionsStreamingClientConfiguration.cs
+++ b/Alpaca.Markets/Parameters/AlpacaOptionsStreamingClientConfiguration.cs
@@ -54,12 +54,11 @@ public sealed class AlpacaOptionsStreamingClientConfiguration : StreamingClientC
         OptionsFeed feed) =>
         new(this, feed);
 
-    internal override Uri GetApiEndpoint()
-    {
-        var baseUrl = base.GetApiEndpoint();
+    internal override Uri GetApiEndpoint() =>
         // Options streaming API uses format: wss://stream.data.alpaca.markets/v1beta1/{feed}
         // where {feed} is either "indicative" or "opra"
-        var feedValue = Feed == OptionsFeed.Opra ? "opra" : "indicative";
-        return new Uri(baseUrl, $"v1beta1/{feedValue}");
-    }
+        new UriBuilder(ApiEndpoint)
+        {
+            Path = $"v1beta1/{(Feed == OptionsFeed.Opra ? "opra" : "indicative")}"
+        }.Uri;
 }

--- a/Alpaca.Markets/PublicAPI.Unshipped.txt
+++ b/Alpaca.Markets/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 ﻿#nullable enable
+Alpaca.Markets.AlpacaDataStreamingClientConfiguration.Feed.get -> Alpaca.Markets.MarketDataFeed?
+Alpaca.Markets.AlpacaDataStreamingClientConfiguration.WithFeed(Alpaca.Markets.MarketDataFeed feed) -> Alpaca.Markets.AlpacaDataStreamingClientConfiguration!
+static Alpaca.Markets.EnvironmentExtensions.GetAlpacaDataStreamingClient(this Alpaca.Markets.IEnvironment! environment, Alpaca.Markets.SecurityKey! securityKey, Alpaca.Markets.MarketDataFeed feed) -> Alpaca.Markets.IAlpacaDataStreamingClient!
+static Alpaca.Markets.EnvironmentExtensions.GetAlpacaDataStreamingClientConfiguration(this Alpaca.Markets.IEnvironment! environment, Alpaca.Markets.SecurityKey! securityKey, Alpaca.Markets.MarketDataFeed feed) -> Alpaca.Markets.AlpacaDataStreamingClientConfiguration!

--- a/Alpaca.Markets/packages.lock.json
+++ b/Alpaca.Markets/packages.lock.json
@@ -683,9 +683,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.20, )",
-        "resolved": "8.0.20",
-        "contentHash": "Rhcto2AjGvTO62+/VTmBpumBOmqIGp7nYEbTbmEXkCq4yPGxV8whju3/HsIA/bKyo2+DggaYk5+/8sxb1AbPTw=="
+        "requested": "[8.0.27, )",
+        "resolved": "8.0.27",
+        "contentHash": "rQi9TxifHRnXP7lVRZH05DxD2/XGbJp12q0ozcbrlBlBnyyzssFTH/2vLhtKWUp2CT1qVscTrcYTFiwTyKPKRg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",


### PR DESCRIPTION
## Description

> Add explicit market data feed selection for the data streaming client

## Type of change

- New feature (non-breaking change which adds functionality)
Add support for all market data feeds within the data streaming client.

## How Has This Been Tested?

- StreamingClientFeedEndpointTest added

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
