### PR TITLE
Make deprecated pattern_day_trader account field optional

### DIFF
--- a/Alpaca.Markets/Messages/JsonAccount.cs
+++ b/Alpaca.Markets/Messages/JsonAccount.cs
@@ -25,7 +25,7 @@ internal sealed class JsonAccount : IAccount
     [JsonProperty(PropertyName = "cash", Required = Required.Always)]
     public Decimal TradableCash { get; set; }
 
-    [JsonProperty(PropertyName = "pattern_day_trader", Required = Required.Always)]
+    [JsonProperty(PropertyName = "pattern_day_trader", Required = Required.Default)]
     public Boolean IsDayPatternTrader { get; set; }
 
     [JsonProperty(PropertyName = "trading_blocked", Required = Required.Always)]


### PR DESCRIPTION
## Description

The account endpoint may omit pattern_day_trader now that PDT-related fields have been deprecated following Alpaca's Intraday Margin Standards change.

This updates JsonAccount so pattern_day_trader is optional instead of required, preventing GetAccountAsync from failing deserialization when the field is absent.

Docs reference:
https://docs.alpaca.markets/us/docs/account-plans

Fixes # (issue)
Alpaca.Markets/Messages/JsonAccount.cs

[JsonProperty(PropertyName = "pattern_day_trader", Required = Required.Default)]
public Boolean IsDayPatternTrader { get; set; }

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested against my account, which was not getting the pattern_day_trader field.


## Checklist:

- [X ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [X ] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings
