### PR TITLE
feat: Remove deprecated properties from IAccount interface and fix JSON property name typo

### DIFF
--- a/Alpaca.Markets.Tests/AlpacaTradingClientTest.Account.cs
+++ b/Alpaca.Markets.Tests/AlpacaTradingClientTest.Account.cs
@@ -17,7 +17,6 @@ public sealed partial class AlpacaTradingClientTest
         const Decimal cash = 10_000M;
         const Decimal transfer = 0M;
         const Int32 multiplier = 4;
-        const UInt64 count = 2UL;
 
         using var mock = mockClientsFactory.GetAlpacaTradingClientMock();
 
@@ -26,7 +25,7 @@ public sealed partial class AlpacaTradingClientTest
             new JProperty("options_approved_level", OptionsTradingLevel.Disabled),
             new JProperty("options_trading_level", OptionsTradingLevel.Disabled),
             new JProperty("crypto_status", AccountStatus.Active),
-            new JProperty("non_maginable_buying_power", Price),
+            new JProperty("non_marginable_buying_power", Price),
             new JProperty("daytrading_buying_power", Price),
             new JProperty("last_maintenance_margin", Price),
             new JProperty("pending_transfer_out", transfer),
@@ -37,7 +36,6 @@ public sealed partial class AlpacaTradingClientTest
             new JProperty("options_buying_power", cash),
             new JProperty("short_market_value", Price),
             new JProperty("maintenance_margin", Price),
-            new JProperty("pattern_day_trader", false),
             new JProperty("regt_buying_power", Price),
             new JProperty("long_market_value", Price),
             new JProperty("transfers_blocked", false),
@@ -47,7 +45,6 @@ public sealed partial class AlpacaTradingClientTest
             new JProperty("shorting_enabled", true),
             new JProperty("multiplier", multiplier),
             new JProperty("initial_margin", Price),
-            new JProperty("daytrade_count", count),
             new JProperty("buying_power", Price),
             new JProperty("last_equity", Price),
             new JProperty("id", Guid.NewGuid()),
@@ -60,7 +57,6 @@ public sealed partial class AlpacaTradingClientTest
         Assert.Equal(Multiplier.Quadruple, account.Multiplier);
         Assert.NotEqual(Guid.NewGuid(), account.AccountId);
         Assert.False(String.IsNullOrEmpty(account.Currency));
-        Assert.Equal(count, account.DayTradeCount);
 
         Assert.Equal(AccountStatus.Active, account.CryptoStatus);
         Assert.Equal(AccountStatus.Active, account.Status);
@@ -91,7 +87,6 @@ public sealed partial class AlpacaTradingClientTest
         Assert.True(account.TradeSuspendedByUser);
         Assert.True(account.ShortingEnabled);
 
-        Assert.False(account.IsDayPatternTrader);
         Assert.False(account.IsTransfersBlocked);
         Assert.False(account.IsTradingBlocked);
         Assert.False(account.IsAccountBlocked);

--- a/Alpaca.Markets/Alpaca.Markets.csproj
+++ b/Alpaca.Markets/Alpaca.Markets.csproj
@@ -19,6 +19,8 @@
 
   <PropertyGroup>
     <PackageReleaseNotes>
+- BREAKING: The `IsDayPatternTrader` and `DayTradeCount` properties were removed from the `IAccount` interface because the corresponding `pattern_day_trader` and `daytrade_count` fields no longer exist in the Alpaca Trading API `Account` response.
+- Fixed a bug where the `NonMarginableBuyingPower` property of the `IAccount` interface was never populated due to a JSON property name typo (`non_maginable_buying_power` instead of `non_marginable_buying_power`).
 - The new `MarginRequirementLong` and `MarginRequirementShort` properties were added to the `IAsset` interface.
 - The old `MaintenanceMarginRequirement` property of the `IAsset` interface is marked as obsolete.
 - The new `Boats` and `Overnight` values were added to the `MarketDataFeed` enumeration.

--- a/Alpaca.Markets/CompatibilitySuppressions.xml
+++ b/Alpaca.Markets/CompatibilitySuppressions.xml
@@ -507,6 +507,20 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Alpaca.Markets.IAccount.get_DayTradeCount</Target>
+    <Left>lib/net462/Alpaca.Markets.dll</Left>
+    <Right>lib/net462/Alpaca.Markets.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Alpaca.Markets.IAccount.get_IsDayPatternTrader</Target>
+    <Left>lib/net462/Alpaca.Markets.dll</Left>
+    <Right>lib/net462/Alpaca.Markets.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Alpaca.Markets.IAlpacaCryptoDataClient.GetLatestBarAsync(Alpaca.Markets.LatestDataRequest,System.Threading.CancellationToken)</Target>
     <Left>lib/net462/Alpaca.Markets.dll</Left>
     <Right>lib/net462/Alpaca.Markets.dll</Right>
@@ -836,6 +850,20 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Alpaca.Markets.IAccount.get_DayTradeCount</Target>
+    <Left>lib/net6.0/Alpaca.Markets.dll</Left>
+    <Right>lib/netstandard2.1/Alpaca.Markets.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Alpaca.Markets.IAccount.get_IsDayPatternTrader</Target>
+    <Left>lib/net6.0/Alpaca.Markets.dll</Left>
+    <Right>lib/netstandard2.1/Alpaca.Markets.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Alpaca.Markets.IAlpacaCryptoDataClient.GetLatestBarAsync(Alpaca.Markets.LatestDataRequest,System.Threading.CancellationToken)</Target>
     <Left>lib/net6.0/Alpaca.Markets.dll</Left>
     <Right>lib/netstandard2.1/Alpaca.Markets.dll</Right>
@@ -1165,6 +1193,20 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Alpaca.Markets.IAccount.get_DayTradeCount</Target>
+    <Left>lib/netstandard2.0/Alpaca.Markets.dll</Left>
+    <Right>lib/netstandard2.0/Alpaca.Markets.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Alpaca.Markets.IAccount.get_IsDayPatternTrader</Target>
+    <Left>lib/netstandard2.0/Alpaca.Markets.dll</Left>
+    <Right>lib/netstandard2.0/Alpaca.Markets.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Alpaca.Markets.IAlpacaCryptoDataClient.GetLatestBarAsync(Alpaca.Markets.LatestDataRequest,System.Threading.CancellationToken)</Target>
     <Left>lib/netstandard2.0/Alpaca.Markets.dll</Left>
     <Right>lib/netstandard2.0/Alpaca.Markets.dll</Right>
@@ -1488,6 +1530,20 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Alpaca.Markets.HistoricalTradesRequest.#ctor(System.String,Alpaca.Markets.IInclusiveTimeInterval)</Target>
+    <Left>lib/netstandard2.1/Alpaca.Markets.dll</Left>
+    <Right>lib/netstandard2.1/Alpaca.Markets.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Alpaca.Markets.IAccount.get_DayTradeCount</Target>
+    <Left>lib/netstandard2.1/Alpaca.Markets.dll</Left>
+    <Right>lib/netstandard2.1/Alpaca.Markets.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Alpaca.Markets.IAccount.get_IsDayPatternTrader</Target>
     <Left>lib/netstandard2.1/Alpaca.Markets.dll</Left>
     <Right>lib/netstandard2.1/Alpaca.Markets.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/Alpaca.Markets/Interfaces/IAccount.cs
+++ b/Alpaca.Markets/Interfaces/IAccount.cs
@@ -49,12 +49,6 @@ public interface IAccount
     String? AccountNumber { get; }
 
     /// <summary>
-    /// Returns <c>true</c> if account is linked to pattern day trader.
-    /// </summary>
-    [UsedImplicitly]
-    Boolean IsDayPatternTrader { get; }
-
-    /// <summary>
     /// Returns <c>true</c> if account trading functions are blocked.
     /// </summary>
     [UsedImplicitly]
@@ -149,12 +143,6 @@ public interface IAccount
     /// </summary>
     [UsedImplicitly]
     Decimal LastMaintenanceMargin { get; }
-
-    /// <summary>
-    /// the current number of day trades that have been made in the last 5 trading days (inclusive of today).
-    /// </summary>
-    [UsedImplicitly]
-    UInt64 DayTradeCount { get; }
 
     /// <summary>
     /// Value of special memorandum account.

--- a/Alpaca.Markets/Messages/JsonAccount.cs
+++ b/Alpaca.Markets/Messages/JsonAccount.cs
@@ -25,9 +25,6 @@ internal sealed class JsonAccount : IAccount
     [JsonProperty(PropertyName = "cash", Required = Required.Always)]
     public Decimal TradableCash { get; set; }
 
-    [JsonProperty(PropertyName = "pattern_day_trader", Required = Required.Always)]
-    public Boolean IsDayPatternTrader { get; set; }
-
     [JsonProperty(PropertyName = "trading_blocked", Required = Required.Always)]
     public Boolean IsTradingBlocked { get; set; }
 
@@ -52,7 +49,7 @@ internal sealed class JsonAccount : IAccount
     [JsonProperty(PropertyName = "daytrading_buying_power", Required = Required.Default)]
     public Decimal? DayTradingBuyingPower { get; set; }
 
-    [JsonProperty(PropertyName = "non_maginable_buying_power", Required = Required.Default)]
+    [JsonProperty(PropertyName = "non_marginable_buying_power", Required = Required.Default)]
     public Decimal? NonMarginableBuyingPower { get; set; }
 
     [JsonProperty(PropertyName = "regt_buying_power", Required = Required.Default)]
@@ -78,9 +75,6 @@ internal sealed class JsonAccount : IAccount
 
     [JsonProperty(PropertyName = "last_maintenance_margin", Required = Required.Default)]
     public Decimal LastMaintenanceMargin { get; set; }
-
-    [JsonProperty(PropertyName = "daytrade_count", Required = Required.Default)]
-    public UInt64 DayTradeCount { get; set; }
 
     [JsonProperty(PropertyName = "sma", Required = Required.Default)]
     public Decimal Sma { get; set; }

--- a/Alpaca.Markets/PublicAPI.Shipped.txt
+++ b/Alpaca.Markets/PublicAPI.Shipped.txt
@@ -394,12 +394,10 @@ Alpaca.Markets.IAccount.BuyingPower.get -> decimal?
 Alpaca.Markets.IAccount.CreatedAtUtc.get -> System.DateTime
 Alpaca.Markets.IAccount.CryptoStatus.get -> Alpaca.Markets.AccountStatus
 Alpaca.Markets.IAccount.Currency.get -> string?
-Alpaca.Markets.IAccount.DayTradeCount.get -> ulong
 Alpaca.Markets.IAccount.DayTradingBuyingPower.get -> decimal?
 Alpaca.Markets.IAccount.Equity.get -> decimal?
 Alpaca.Markets.IAccount.InitialMargin.get -> decimal?
 Alpaca.Markets.IAccount.IsAccountBlocked.get -> bool
-Alpaca.Markets.IAccount.IsDayPatternTrader.get -> bool
 Alpaca.Markets.IAccount.IsTradingBlocked.get -> bool
 Alpaca.Markets.IAccount.IsTransfersBlocked.get -> bool
 Alpaca.Markets.IAccount.LastEquity.get -> decimal

--- a/Alpaca.Markets/PublicAPI.Unshipped.txt
+++ b/Alpaca.Markets/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 ﻿#nullable enable
+*REMOVED*Alpaca.Markets.IAccount.DayTradeCount.get -> ulong
+*REMOVED*Alpaca.Markets.IAccount.IsDayPatternTrader.get -> bool


### PR DESCRIPTION
## Description

- Removed `IsDayPatternTrader` and `DayTradeCount` properties from the `IAccount` interface due to changes in the Alpaca Trading API.
- Fixed a typo in the JSON property name for `NonMarginableBuyingPower` to ensure correct population.
- Updated compatibility suppressions to reflect the removal of the deprecated properties.

Fixes # (issue)

- #817

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
