### PR TITLE
fix: prevent GetAccountAsync crash and fix non-marginable buying power typo

### DIFF
--- a/Alpaca.Markets.Tests/AlpacaTradingClientTest.Account.cs
+++ b/Alpaca.Markets.Tests/AlpacaTradingClientTest.Account.cs
@@ -26,7 +26,7 @@ public sealed partial class AlpacaTradingClientTest
             new JProperty("options_approved_level", OptionsTradingLevel.Disabled),
             new JProperty("options_trading_level", OptionsTradingLevel.Disabled),
             new JProperty("crypto_status", AccountStatus.Active),
-            new JProperty("non_maginable_buying_power", Price),
+            new JProperty("non_marginable_buying_power", Price),
             new JProperty("daytrading_buying_power", Price),
             new JProperty("last_maintenance_margin", Price),
             new JProperty("pending_transfer_out", transfer),
@@ -95,6 +95,31 @@ public sealed partial class AlpacaTradingClientTest
         Assert.False(account.IsTransfersBlocked);
         Assert.False(account.IsTradingBlocked);
         Assert.False(account.IsAccountBlocked);
+    }
+
+    [Fact]
+    public async Task GetAccountAsyncWorksWithoutRemovedFields()
+    {
+        // The Alpaca Trading API stopped returning the "pattern_day_trader" and
+        // "daytrade_count" fields. Deserialization must not fail because of that,
+        // and the corresponding properties should fall back to their defaults.
+        const Decimal cash = 10_000M;
+
+        using var mock = mockClientsFactory.GetAlpacaTradingClientMock();
+
+        mock.AddGet("/v2/account", new JObject(
+            new JProperty("status", AccountStatus.Active),
+            new JProperty("created_at", DateTime.UtcNow),
+            new JProperty("trading_blocked", false),
+            new JProperty("transfers_blocked", false),
+            new JProperty("account_blocked", false),
+            new JProperty("id", Guid.NewGuid()),
+            new JProperty("cash", cash)));
+
+        var account = await mock.Client.GetAccountAsync();
+
+        Assert.False(account.IsDayPatternTrader);
+        Assert.Equal(0UL, account.DayTradeCount);
     }
 
     [Fact]

--- a/Alpaca.Markets/Alpaca.Markets.csproj
+++ b/Alpaca.Markets/Alpaca.Markets.csproj
@@ -12,13 +12,15 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <AssemblyVersion>7.2.0.1</AssemblyVersion>
-    <FileVersion>7.2.0.1</FileVersion>
-    <Version>7.2.0</Version>
+    <AssemblyVersion>7.2.1.0</AssemblyVersion>
+    <FileVersion>7.2.1.0</FileVersion>
+    <Version>7.2.1</Version>
   </PropertyGroup>
 
   <PropertyGroup>
     <PackageReleaseNotes>
+- Fixed a bug where `IAccount.NonMarginableBuyingPower` was never populated due to a JSON property name typo (`non_maginable_buying_power` instead of `non_marginable_buying_power`).
+- Fixed a bug where `GetAccountAsync` threw a deserialization exception because the `pattern_day_trader` field is no longer returned by the Alpaca Trading API. The `IAccount.IsDayPatternTrader` and `IAccount.DayTradeCount` properties are deprecated in behavior (they always return their default values now) but remain in the interface for backward compatibility.
 - The `IAlpdaDataClient.ListCorporateActionsAsync` function was added to support historical corporate actions request/response.
     </PackageReleaseNotes>
     <Description>C# SDK for Alpaca Trade API https://docs.alpaca.markets/</Description>

--- a/Alpaca.Markets/Interfaces/IAccount.cs
+++ b/Alpaca.Markets/Interfaces/IAccount.cs
@@ -51,6 +51,10 @@ public interface IAccount
     /// <summary>
     /// Returns <c>true</c> if account is linked to pattern day trader.
     /// </summary>
+    /// <remarks>
+    /// The Alpaca Trading API no longer returns this field. This property always
+    /// returns <c>false</c> and is kept only for backward binary/source compatibility.
+    /// </remarks>
     [UsedImplicitly]
     Boolean IsDayPatternTrader { get; }
 
@@ -153,6 +157,10 @@ public interface IAccount
     /// <summary>
     /// the current number of day trades that have been made in the last 5 trading days (inclusive of today).
     /// </summary>
+    /// <remarks>
+    /// The Alpaca Trading API no longer returns this field. This property always
+    /// returns <c>0</c> and is kept only for backward binary/source compatibility.
+    /// </remarks>
     [UsedImplicitly]
     UInt64 DayTradeCount { get; }
 

--- a/Alpaca.Markets/Messages/JsonAccount.cs
+++ b/Alpaca.Markets/Messages/JsonAccount.cs
@@ -25,7 +25,10 @@ internal sealed class JsonAccount : IAccount
     [JsonProperty(PropertyName = "cash", Required = Required.Always)]
     public Decimal TradableCash { get; set; }
 
-    [JsonProperty(PropertyName = "pattern_day_trader", Required = Required.Always)]
+    // The "pattern_day_trader" field is no longer returned by the Alpaca Trading API.
+    // Required is relaxed to Default (from Always) so deserialization does not fail
+    // when the field is absent; the property now always defaults to false.
+    [JsonProperty(PropertyName = "pattern_day_trader", Required = Required.Default)]
     public Boolean IsDayPatternTrader { get; set; }
 
     [JsonProperty(PropertyName = "trading_blocked", Required = Required.Always)]
@@ -52,7 +55,7 @@ internal sealed class JsonAccount : IAccount
     [JsonProperty(PropertyName = "daytrading_buying_power", Required = Required.Default)]
     public Decimal? DayTradingBuyingPower { get; set; }
 
-    [JsonProperty(PropertyName = "non_maginable_buying_power", Required = Required.Default)]
+    [JsonProperty(PropertyName = "non_marginable_buying_power", Required = Required.Default)]
     public Decimal? NonMarginableBuyingPower { get; set; }
 
     [JsonProperty(PropertyName = "regt_buying_power", Required = Required.Default)]


### PR DESCRIPTION
## Description

The Alpaca Trading API stopped returning the pattern_day_trader field, which JsonAccount required (Required.Always), causing GetAccountAsync to throw a JsonSerializationException for every caller on this version. Required is relaxed to Default so deserialization succeeds; the IsDayPatternTrader and DayTradeCount properties now simply default to false/0 since the API no longer sends this data.

Also fixes a long-standing JSON property name typo (non_maginable_buying_power) that meant NonMarginableBuyingPower was never populated.

This is a non-breaking patch for the 7.2.x line, based on the sdk7.2.0 tag. The breaking removal of IsDayPatternTrader/DayTradeCount is reserved for the upcoming v8 major release.

Fixes #817 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
