### PR TITLE
improvement: fix options streaming endpoint path construction

### DIFF
--- a/Alpaca.Markets.Tests/AlpacaOptionsStreamingClientConfigurationTest.cs
+++ b/Alpaca.Markets.Tests/AlpacaOptionsStreamingClientConfigurationTest.cs
@@ -1,5 +1,3 @@
-using System.Reflection;
-
 namespace Alpaca.Markets.Tests;
 
 public sealed class AlpacaOptionsStreamingClientConfigurationTest
@@ -9,7 +7,7 @@ public sealed class AlpacaOptionsStreamingClientConfigurationTest
     {
         var configuration = new AlpacaOptionsStreamingClientConfiguration();
 
-        var endpoint = InvokeGetApiEndpoint(configuration);
+        var endpoint = configuration.GetApiEndpoint();
 
         Assert.Equal("wss://stream.data.alpaca.markets/v1beta1/indicative", endpoint.AbsoluteUri);
         Assert.Equal("/v1beta1/indicative", endpoint.AbsolutePath);
@@ -20,7 +18,7 @@ public sealed class AlpacaOptionsStreamingClientConfigurationTest
     {
         var configuration = new AlpacaOptionsStreamingClientConfiguration(OptionsFeed.Opra);
 
-        var endpoint = InvokeGetApiEndpoint(configuration);
+        var endpoint = configuration.GetApiEndpoint();
 
         Assert.Equal("wss://stream.data.alpaca.markets/v1beta1/opra", endpoint.AbsoluteUri);
         Assert.Equal("/v1beta1/opra", endpoint.AbsolutePath);
@@ -32,24 +30,9 @@ public sealed class AlpacaOptionsStreamingClientConfigurationTest
         var configuration = new AlpacaOptionsStreamingClientConfiguration(OptionsFeed.Indicative)
             .WithFeed(OptionsFeed.Opra);
 
-        var endpoint = InvokeGetApiEndpoint(configuration);
+        var endpoint = configuration.GetApiEndpoint();
 
         Assert.Equal("wss://stream.data.alpaca.markets/v1beta1/opra", endpoint.AbsoluteUri);
         Assert.Equal("/v1beta1/opra", endpoint.AbsolutePath);
-    }
-
-    private static Uri InvokeGetApiEndpoint(AlpacaOptionsStreamingClientConfiguration configuration)
-    {
-        // Use reflection to invoke the internal GetApiEndpoint() method for unit testing.
-        // This allows testing the endpoint construction logic without exposing it publicly.
-        var method = typeof(AlpacaOptionsStreamingClientConfiguration)
-            .GetMethod("GetApiEndpoint", BindingFlags.Instance | BindingFlags.NonPublic);
-
-        Assert.NotNull(method);
-
-        var endpoint = method!.Invoke(configuration, null);
-        Assert.NotNull(endpoint);
-
-        return Assert.IsType<Uri>(endpoint);
     }
 }

--- a/Alpaca.Markets.Tests/AlpacaOptionsStreamingClientConfigurationTest.cs
+++ b/Alpaca.Markets.Tests/AlpacaOptionsStreamingClientConfigurationTest.cs
@@ -1,0 +1,54 @@
+using System.Reflection;
+
+namespace Alpaca.Markets.Tests;
+
+public sealed class AlpacaOptionsStreamingClientConfigurationTest
+{
+    [Fact]
+    public void GetApiEndpoint_UsesIndicativePath_ForDefaultConfiguration()
+    {
+        var configuration = new AlpacaOptionsStreamingClientConfiguration();
+
+        var endpoint = InvokeGetApiEndpoint(configuration);
+
+        Assert.Equal("wss://stream.data.alpaca.markets/v1beta1/indicative", endpoint.AbsoluteUri);
+        Assert.Equal("/v1beta1/indicative", endpoint.AbsolutePath);
+        Assert.DoesNotContain("/v1beta1/v1beta1/", endpoint.AbsolutePath);
+    }
+
+    [Fact]
+    public void GetApiEndpoint_UsesOpraPath_ForOpraFeed()
+    {
+        var configuration = new AlpacaOptionsStreamingClientConfiguration(OptionsFeed.Opra);
+
+        var endpoint = InvokeGetApiEndpoint(configuration);
+
+        Assert.Equal("wss://stream.data.alpaca.markets/v1beta1/opra", endpoint.AbsoluteUri);
+        Assert.Equal("/v1beta1/opra", endpoint.AbsolutePath);
+    }
+
+    [Fact]
+    public void WithFeed_UpdatesEndpointPath()
+    {
+        var configuration = new AlpacaOptionsStreamingClientConfiguration(OptionsFeed.Indicative)
+            .WithFeed(OptionsFeed.Opra);
+
+        var endpoint = InvokeGetApiEndpoint(configuration);
+
+        Assert.Equal("wss://stream.data.alpaca.markets/v1beta1/opra", endpoint.AbsoluteUri);
+        Assert.Equal("/v1beta1/opra", endpoint.AbsolutePath);
+    }
+
+    private static Uri InvokeGetApiEndpoint(AlpacaOptionsStreamingClientConfiguration configuration)
+    {
+        var method = typeof(AlpacaOptionsStreamingClientConfiguration)
+            .GetMethod("GetApiEndpoint", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(method);
+
+        var endpoint = method!.Invoke(configuration, null);
+        Assert.NotNull(endpoint);
+
+        return Assert.IsType<Uri>(endpoint);
+    }
+}

--- a/Alpaca.Markets.Tests/AlpacaOptionsStreamingClientConfigurationTest.cs
+++ b/Alpaca.Markets.Tests/AlpacaOptionsStreamingClientConfigurationTest.cs
@@ -13,7 +13,6 @@ public sealed class AlpacaOptionsStreamingClientConfigurationTest
 
         Assert.Equal("wss://stream.data.alpaca.markets/v1beta1/indicative", endpoint.AbsoluteUri);
         Assert.Equal("/v1beta1/indicative", endpoint.AbsolutePath);
-        Assert.DoesNotContain("/v1beta1/v1beta1/", endpoint.AbsolutePath);
     }
 
     [Fact]
@@ -41,6 +40,8 @@ public sealed class AlpacaOptionsStreamingClientConfigurationTest
 
     private static Uri InvokeGetApiEndpoint(AlpacaOptionsStreamingClientConfiguration configuration)
     {
+        // Use reflection to invoke the internal GetApiEndpoint() method for unit testing.
+        // This allows testing the endpoint construction logic without exposing it publicly.
         var method = typeof(AlpacaOptionsStreamingClientConfiguration)
             .GetMethod("GetApiEndpoint", BindingFlags.Instance | BindingFlags.NonPublic);
 

--- a/Alpaca.Markets/Alpaca.Markets.csproj
+++ b/Alpaca.Markets/Alpaca.Markets.csproj
@@ -85,6 +85,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Alpaca.Markets.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010075944e93a9e5981863853b33c605d0e67449ad9a0d90bbca7229ee052bb8d6f8136322bc7ca252ab472172a4a12e50d532c19fb0fe258c07a60820eff7c61753ff12993a0a0ce8cabe9a793c98be1f794e741ba776ce4b8df3873a6e7d6774e0c577eb3198b1930bc41ef82a829bf20b5edef2563a65213a04b49e7ae17e52b9" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="..\Icon.png" Pack="true" PackagePath="icon.png" />
     <None Include="README.md" Pack="true" PackagePath="\" />
     <None Remove="Alpaca.Markets.csproj.DotSettings" />

--- a/Alpaca.Markets/Parameters/AlpacaOptionsStreamingClientConfiguration.cs
+++ b/Alpaca.Markets/Parameters/AlpacaOptionsStreamingClientConfiguration.cs
@@ -57,9 +57,11 @@ public sealed class AlpacaOptionsStreamingClientConfiguration : StreamingClientC
     internal override Uri GetApiEndpoint()
     {
         var feedValue = Feed == OptionsFeed.Opra ? "opra" : "indicative";
-        return new UriBuilder(base.GetApiEndpoint())
-        {
-            Path = $"v1beta1/{feedValue}"
-        }.Uri;
+        // Construct the endpoint by treating the feed name as a relative URI.
+        // When baseUrl ends in /v1beta1/opra or /v1beta1/indicative, the relative
+        // path "opra" or "indicative" replaces the last segment, which correctly
+        // switches between feeds without duplicating the /v1beta1 prefix.
+        // This approach works for the designed environments (Live and Paper).
+        return new Uri(base.GetApiEndpoint(), feedValue);
     }
 }

--- a/Alpaca.Markets/Parameters/AlpacaOptionsStreamingClientConfiguration.cs
+++ b/Alpaca.Markets/Parameters/AlpacaOptionsStreamingClientConfiguration.cs
@@ -56,10 +56,10 @@ public sealed class AlpacaOptionsStreamingClientConfiguration : StreamingClientC
 
     internal override Uri GetApiEndpoint()
     {
-        var baseUrl = base.GetApiEndpoint();
-        // Options streaming API uses format: wss://stream.data.alpaca.markets/v1beta1/{feed}
-        // where {feed} is either "indicative" or "opra"
         var feedValue = Feed == OptionsFeed.Opra ? "opra" : "indicative";
-        return new Uri(baseUrl, feedValue);
+        return new UriBuilder(base.GetApiEndpoint())
+        {
+            Path = $"v1beta1/{feedValue}"
+        }.Uri;
     }
 }


### PR DESCRIPTION
## Summary
This PR improves the options streaming endpoint handling introduced in #806 by ensuring `AlpacaOptionsStreamingClientConfiguration.GetApiEndpoint()` builds the final URI with a single `/v1beta1/{feed}` path instead of potentially duplicating `/v1beta1/` segments.

It also adds regression tests covering:
- the default indicative endpoint
- the OPRA feed endpoint
- `WithFeed(...)` updates

## Testing
- `DOTNET_ROLL_FORWARD=Major dotnet test Alpaca.Markets.Tests/Alpaca.Markets.Tests.csproj --filter "FullyQualifiedName~AlpacaOptionsStreamingClientConfigurationTest" -p:RestoreLockedMode=false`

## Notes
- This is intended as an improvement to #806.
