### PR TITLE
fix: format User-Agent header as APCA-<PLATFORM>/<sdk-version> <Runtime>/<runtime-version>

### DIFF
--- a/Alpaca.Markets.Tests/HttpClientExtensionsTest.cs
+++ b/Alpaca.Markets.Tests/HttpClientExtensionsTest.cs
@@ -1,0 +1,94 @@
+using System.Net.Http.Headers;
+
+namespace Alpaca.Markets.Tests;
+
+public sealed class HttpClientExtensionsTest
+{
+    // Real value observed on Mono/Xamarin runtimes. Mono.Runtime.GetDisplayName()'s format
+    // is explicitly documented as unstable and commonly includes characters (parentheses,
+    // colons, slashes) that are invalid inside an HTTP product token.
+    private const String MonoFrameworkDescription =
+        "Mono 6.12.0.122 (2020-02/8e1b8f4 Fri Feb 14 12:20:22 EST 2020)";
+
+    [Fact]
+    public void ConfigureSetsUserAgentHeaderInExpectedFormat()
+    {
+        using var httpClient = new HttpClient();
+        var securityKey = new SecretKey(
+            Guid.NewGuid().ToString("N"), Guid.NewGuid().ToString("N"));
+
+        httpClient.Configure(securityKey, new Uri("https://paper-api.alpaca.markets"));
+
+        var userAgent = httpClient.DefaultRequestHeaders.UserAgent.ToList();
+
+        Assert.Equal(2, userAgent.Count);
+        assertValidProductToken(userAgent[0], "APCA-DOTNET");
+        assertValidProductToken(userAgent[1]);
+
+        return;
+
+        static void assertValidProductToken(
+            ProductInfoHeaderValue productInfo,
+            String? expectedName = null)
+        {
+            var product = productInfo.Product;
+
+            Assert.NotNull(product);
+            Assert.False(String.IsNullOrEmpty(product!.Version));
+            Assert.DoesNotContain(' ', product.Name);
+            Assert.DoesNotContain(' ', product.Version!);
+            Assert.Matches(@"^\d+(\.\d+){1,3}$", product.Version!);
+
+            if (expectedName is not null)
+            {
+                Assert.Equal(expectedName, product.Name);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(".NET 8.0.7", ".NET", "8.0.7")]
+    [InlineData(".NET Core 3.1.32", ".NETCore", "3.1.32")]
+    [InlineData(".NET Framework 4.8.9037.0", ".NETFramework", "4.8.9037.0")]
+    [InlineData("Mono 6.12.0.122", "Mono", "6.12.0.122")]
+    public void ParseRuntimeInfoParsesKnownFrameworkDescriptions(
+        String frameworkDescription,
+        String expectedName,
+        String expectedVersion)
+    {
+        var (name, version) = HttpClientExtensions.ParseRuntimeInfo(frameworkDescription);
+
+        Assert.Equal(expectedName, name);
+        Assert.Equal(expectedVersion, version);
+    }
+
+    [Theory]
+    [InlineData(MonoFrameworkDescription)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("SomeRuntimeWithNoVersionAtAll")]
+    [InlineData("Weird/Runtime:Name (with) [separators] 1.2.3")]
+    public void ParseRuntimeInfoNeverProducesAnInvalidProductToken(
+        String frameworkDescription)
+    {
+        var (name, version) = HttpClientExtensions.ParseRuntimeInfo(frameworkDescription);
+
+        Assert.False(String.IsNullOrEmpty(name));
+        Assert.False(String.IsNullOrEmpty(version));
+
+        // The real regression: constructing the header value must never throw, no matter
+        // how malformed the underlying runtime description is (e.g. Mono's, which is
+        // explicitly documented as an unstable format).
+        var exception = Record.Exception(() => new ProductInfoHeaderValue(name, version));
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void ParseRuntimeInfoExtractsRealMonoVersionFromNoisyDescription()
+    {
+        var (name, version) = HttpClientExtensions.ParseRuntimeInfo(MonoFrameworkDescription);
+
+        Assert.Equal("Mono", name);
+        Assert.Equal("6.12.0.122", version);
+    }
+}

--- a/Alpaca.Markets/Helpers/HttpClientExtensions.cs
+++ b/Alpaca.Markets/Helpers/HttpClientExtensions.cs
@@ -1,11 +1,22 @@
 ﻿using System.Net.Http.Headers;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 
 namespace Alpaca.Markets;
 
 internal static partial class HttpClientExtensions
 {
+    // Matches a dotted version number (2 to 4 components) anywhere in a runtime
+    // description string, e.g. "8.0.7" in ".NET 8.0.7" or "6.12.0.122" in
+    // "Mono 6.12.0.122 (...)".
+    private static readonly Regex _runtimeVersionPattern = new(
+        @"\d+(\.\d+){1,3}", RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
     private static readonly String _sdkVersion =
-        typeof(HttpClientExtensions).Assembly.GetName().Version!.ToString();
+        typeof(HttpClientExtensions).Assembly.GetName().Version!.ToString(3);
+
+    private static readonly (String Name, String Version) _runtimeInfo =
+        ParseRuntimeInfo(RuntimeInformation.FrameworkDescription);
 
     private static readonly Version _httpVersion =
 #if NETSTANDARD2_1 || NET6_0_OR_GREATER
@@ -31,7 +42,9 @@ internal static partial class HttpClientExtensions
         httpClient.DefaultRequestHeaders.AcceptEncoding
             .Add(new StringWithQualityHeaderValue("gzip"));
         httpClient.DefaultRequestHeaders.UserAgent.Add(
-            new ProductInfoHeaderValue("Alpaca-dotNET-SDK", _sdkVersion));
+            new ProductInfoHeaderValue("APCA-DOTNET", _sdkVersion));
+        httpClient.DefaultRequestHeaders.UserAgent.Add(
+            new ProductInfoHeaderValue(_runtimeInfo.Name, _runtimeInfo.Version));
         httpClient.BaseAddress = baseAddress;
 
 #if NETFRAMEWORK
@@ -129,6 +142,37 @@ internal static partial class HttpClientExtensions
         return await response.IsSuccessStatusCodeAsync()
             .ConfigureAwait(false);
     }
+
+    // Internal (rather than private) so tests can validate parsing of arbitrary/malformed
+    // runtime descriptions (e.g. Mono's, whose format is explicitly documented as unstable)
+    // without needing to run on every target runtime.
+    internal static (String Name, String Version) ParseRuntimeInfo(
+        String frameworkDescription)
+    {
+        // Splits ".NET 8.0.7" into (".NET", "8.0.7") or "Mono 6.12.0.122 (2020-02/8e1b8f4 ...)"
+        // into ("Mono", "6.12.0.122") by locating the first dotted version number.
+        var match = _runtimeVersionPattern.Match(frameworkDescription);
+
+        var name = sanitizeProductToken(match.Success
+            ? frameworkDescription[..match.Index]
+            : frameworkDescription);
+        var version = match.Success
+            ? match.Value
+            : Environment.Version.ToString();
+
+        // HTTP product tokens (RFC 7230) can't be empty and can't contain separator
+        // characters (spaces, parentheses, slashes, colons, etc.) - strip anything else
+        // out so a surprising runtime description can never crash header construction.
+        return (String.IsNullOrEmpty(name) ? ".NET" : name, version);
+    }
+
+    private static String sanitizeProductToken(
+        String value) =>
+        new(value.Where(isProductTokenChar).ToArray());
+
+    private static Boolean isProductTokenChar(
+        Char character) =>
+        Char.IsLetterOrDigit(character) || character is '.' or '-' or '_' or '+';
 
     private static Uri asUri(String endpointUri) => new(endpointUri, UriKind.RelativeOrAbsolute);
 


### PR DESCRIPTION
## Description

Aligns the SDK's User-Agent header with Alpaca's cross-SDK convention (e.g. `APCA-DOTNET/8.0.0 .NET/8.0.7`) instead of the previous free-form `Alpaca-dotNET-SDK/<version>` token, adding a separate runtime product token parsed from RuntimeInformation.FrameworkDescription.

Runtime-description parsing is sanitized to only valid HTTP token characters so unpredictable formats (e.g. Mono's, which is documented as unstable) can never throw and break HttpClient configuration.

Note: Once approved I will backport it to v 7.2.x

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
