### PR TITLE
docs: migrate SDK documentation to GitHub Pages

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,6 +2,9 @@ name: Update Documentation
 
 on: [workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Create Documentation
@@ -27,45 +30,29 @@ jobs:
     - name: Restore .NET Tools
       run: dotnet tool restore
 
+    - name: Configure GitHub Pages
+      uses: actions/configure-pages@v5
+
     - name: Build Documentation
       run: dotnet docfx Documentation/docfx.json
 
-    - name: Save Documentation
-      uses: actions/upload-artifact@v7
+    - name: Upload GitHub Pages Artifact
+      uses: actions/upload-pages-artifact@v4
       with:
-        retention-days: 1
-        compression-level: 0
-        name: documentation
         path: Documentation/_site/
 
-  publish:
+  deploy:
     name: Publish Documentation
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
 
     steps:
-    - name: Checkout Branch
-      uses: actions/checkout@v7
-      with:
-        ref: gh-pages
-
-    - name: Set Git Identity
-      run: |
-        git config user.name "GitHub Actions"
-        git config user.email "github-actions@github.com"
-
-    - name: Delete Documenation
-      run: |
-        rm -rfv ./*
-        git rm ** -f
-
-    - name: Load Documentation
-      uses: actions/download-artifact@v8
-      with:
-        name: documentation
-
-    - name: Commit and Push
-      run: |
-        git add ** -f
-        git commit -m "Update content of .NET SDK documentation on GitHub Pages web site."
-        git push origin gh-pages
+    - name: Deploy GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,15 +12,15 @@ jobs:
     
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v6
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
       with:
         global-json-file: global.json
 
     - name: Cache NuGet Packages
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:
         path: ~/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
@@ -31,13 +31,13 @@ jobs:
       run: dotnet tool restore
 
     - name: Configure GitHub Pages
-      uses: actions/configure-pages@v5
+      uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
     - name: Build Documentation
       run: dotnet docfx Documentation/docfx.json
 
     - name: Upload GitHub Pages Artifact
-      uses: actions/upload-pages-artifact@v4
+      uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
       with:
         path: Documentation/_site/
 
@@ -55,4 +55,4 @@ jobs:
     steps:
     - name: Deploy GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/Alpaca.Markets.Extensions/README.md
+++ b/Alpaca.Markets.Extensions/README.md
@@ -6,7 +6,7 @@ utm_source=website&utm_medium=github&utm_campaign=open_source)
 # .NET SDK for Alpaca Markets API
 
 This package contains helper extensions methods for the [C#/.NET SDK](https://github.com/alpacahq/alpaca-trade-api-csharp) for [Alpaca Trade API](https://docs.alpaca.markets/).
-See complete online documentation [here](https://olegra.github.io/Alpaca.Markets/api/Alpaca.Markets.Extensions.html).
+See complete online documentation [here](https://alpacahq.github.io/alpaca-trade-api-csharp/api/Alpaca.Markets.Extensions.html).
 
 ## .NET Core Usage Example
 

--- a/Alpaca.Markets/README.md
+++ b/Alpaca.Markets/README.md
@@ -4,7 +4,7 @@
 
 # .NET SDK for Alpaca Markets API
 
-This package contains C#/.NET SDK for [Alpaca Trade API](https://docs.alpaca.markets/). See complete online documentation [here](https://olegra.github.io/Alpaca.Markets/api/Alpaca.Markets.html).
+This package contains C#/.NET SDK for [Alpaca Trade API](https://docs.alpaca.markets/). See complete online documentation [here](https://alpacahq.github.io/alpaca-trade-api-csharp/api/Alpaca.Markets.html).
 
 ## .NET Core Usage Example
 

--- a/Documentation/serve.cmd
+++ b/Documentation/serve.cmd
@@ -1,0 +1,7 @@
+@echo off
+setlocal
+
+cd /d "%~dp0.."
+dotnet tool restore || exit /b 1
+dotnet docfx Documentation/docfx.json --serve
+exit /b %errorlevel%

--- a/Documentation/serve.sh
+++ b/Documentation/serve.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repository_root=$(dirname -- "$script_dir")
+
+cd "$repository_root"
+dotnet tool restore
+exec dotnet docfx Documentation/docfx.json --serve

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 | Package | Stable | Pre-release |
 | ------- | ------ | ----------- |
-| [Alpaca.Markets](https://olegra.github.io/Alpaca.Markets/api/Alpaca.Markets.html) | [![Nuget](https://img.shields.io/nuget/v/Alpaca.Markets?logo=NuGet)](https://www.nuget.org/packages/Alpaca.Markets) | [![Nuget](https://img.shields.io/nuget/vpre/Alpaca.Markets?logo=NuGet)](https://www.nuget.org/packages/Alpaca.Markets/absoluteLatest) |
-| [Alpaca.Markets.Extensions](https://olegra.github.io/Alpaca.Markets/api/Alpaca.Markets.Extensions.html) | [![Nuget](https://img.shields.io/nuget/v/Alpaca.Markets.Extensions?logo=NuGet)](https://www.nuget.org/packages/Alpaca.Markets.Extensions) | [![Nuget](https://img.shields.io/nuget/vpre/Alpaca.Markets.Extensions?logo=NuGet)](https://www.nuget.org/packages/Alpaca.Markets.Extensions/absoluteLatest) |
+| [Alpaca.Markets](https://alpacahq.github.io/alpaca-trade-api-csharp/api/Alpaca.Markets.html) | [![Nuget](https://img.shields.io/nuget/v/Alpaca.Markets?logo=NuGet)](https://www.nuget.org/packages/Alpaca.Markets) | [![Nuget](https://img.shields.io/nuget/vpre/Alpaca.Markets?logo=NuGet)](https://www.nuget.org/packages/Alpaca.Markets/absoluteLatest) |
+| [Alpaca.Markets.Extensions](https://alpacahq.github.io/alpaca-trade-api-csharp/api/Alpaca.Markets.Extensions.html) | [![Nuget](https://img.shields.io/nuget/v/Alpaca.Markets.Extensions?logo=NuGet)](https://www.nuget.org/packages/Alpaca.Markets.Extensions) | [![Nuget](https://img.shields.io/nuget/vpre/Alpaca.Markets.Extensions?logo=NuGet)](https://www.nuget.org/packages/Alpaca.Markets.Extensions/absoluteLatest) |
 
 ## .NET Core Usage Example
 
@@ -63,6 +63,27 @@ Use the `Environments.Paper.GetAlpacaDataStreamingClient(...)` factory method to
 1.  Install your OS's latest version of the [.NET 9.0 SDK](https://dotnet.microsoft.com/download).
 2.  Clone the local version of this repository or your fork (if you want to make changes).
 3.  Build the packages using the `dotnet build` command running in the root directory of the cloned repo.
+
+### Preview the documentation locally
+
+The preview helper restores the pinned DocFX tool, builds the documentation,
+and starts DocFX's local server.
+
+On macOS or Linux:
+
+```bash
+./Documentation/serve.sh
+```
+
+On Windows:
+
+```cmd
+Documentation\serve.cmd
+```
+
+Open the local URL printed by DocFX, usually
+[`http://localhost:8080`](http://localhost:8080). Stop the server with
+<kbd>Ctrl</kbd>+<kbd>C</kbd>.
 
 ## Contributors
 


### PR DESCRIPTION
## Description

- deploy DocFX output through the official Pages workflow
- update API links to the repository-owned Pages site
- add cross-platform local documentation preview helpers

## Type of change

- Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
