### PR TITLE
Add .NET 10 multi-targeting (keep net8)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ jobs:
       uses: actions/setup-dotnet@v6
       with:
         global-json-file: global.json
+        dotnet-version: |
+          8.0.x
+          10.0.x
 
     - name: Cache NuGet Packages
       uses: actions/cache@v6

--- a/Alpaca.Markets.Extensions.Tests/Alpaca.Markets.Extensions.Tests.csproj
+++ b/Alpaca.Markets.Extensions.Tests/Alpaca.Markets.Extensions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>..\Alpaca.Markets.snk</AssemblyOriginatorKeyFile>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -13,20 +13,28 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.11" />
+  </ItemGroup>
+
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.8" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.3" />
+    <PackageReference Include="System.Threading.Channels" Version="9.0.8" />
+    <PackageReference Include="System.IO.Pipelines" Version="9.0.8" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.1.0" />
-    <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Threading.Channels" Version="10.0.11" />
-    <PackageReference Include="System.IO.Pipelines" Version="10.0.11" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Polly" Version="8.7.0" />
   </ItemGroup>

--- a/Alpaca.Markets.Extensions.Tests/AlpacaDataClientTest.cs
+++ b/Alpaca.Markets.Extensions.Tests/AlpacaDataClientTest.cs
@@ -39,7 +39,7 @@ public sealed partial class AlpacaDataClientTest(
 
     private static async ValueTask<Int32> validateListOfLists<TItem>(
         IAsyncEnumerable<IReadOnlyList<TItem>> pages) =>
-        await pages.SumAsync(items => items.Count);
+        await pages.Select(items => items.Count).SumAsync();
 
     private static async Task<Int32> validateDictionaryOfLists<TItem>(
         IReadOnlyDictionary<String, IAsyncEnumerable<TItem>> dictionary) =>
@@ -47,7 +47,7 @@ public sealed partial class AlpacaDataClientTest(
 
     private static async ValueTask<Int32> validateListOfDictionariesOfLists<TItem>(
         IAsyncEnumerable<IReadOnlyDictionary<String, IReadOnlyList<TItem>>> pages) =>
-        await pages.SumAsync(dictionary => dictionary.Values.Sum(items => items.Count));
+        await pages.Select(dictionary => dictionary.Values.Sum(items => items.Count)).SumAsync();
 
     private static Interval<DateTime> getTimeInterval()
     {

--- a/Alpaca.Markets.Extensions.Tests/AlpacaOptionsDataClientTest.cs
+++ b/Alpaca.Markets.Extensions.Tests/AlpacaOptionsDataClientTest.cs
@@ -42,7 +42,7 @@ public sealed partial class AlpacaOptionsDataClientTest(
 
     private static async ValueTask<Int32> validateListOfLists<TItem>(
         IAsyncEnumerable<IReadOnlyList<TItem>> pages) =>
-        await pages.SumAsync(items => items.Count);
+        await pages.Select(items => items.Count).SumAsync();
 
     private static async Task<Int32> validateDictionaryOfLists<TItem>(
         IReadOnlyDictionary<String, IAsyncEnumerable<TItem>> dictionary) =>
@@ -50,7 +50,7 @@ public sealed partial class AlpacaOptionsDataClientTest(
 
     private static async ValueTask<Int32> validateListOfDictionariesOfLists<TItem>(
         IAsyncEnumerable<IReadOnlyDictionary<String, IReadOnlyList<TItem>>> pages) =>
-        await pages.SumAsync(dictionary => dictionary.Values.Sum(items => items.Count));
+        await pages.Select(dictionary => dictionary.Values.Sum(items => items.Count)).SumAsync();
 
     private static Interval<DateTime> getTimeInterval()
     {

--- a/Alpaca.Markets.Extensions/Alpaca.Markets.Extensions.csproj
+++ b/Alpaca.Markets.Extensions/Alpaca.Markets.Extensions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net8.0;net10.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>..\Alpaca.Markets.snk</AssemblyOriginatorKeyFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -57,7 +57,7 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 
-  <PropertyGroup Condition="($(TargetFramework.StartsWith('net8')))">
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
@@ -101,7 +101,18 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.11" PrivateAssets="compile;contentfiles;build;analyzers" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.11" PrivateAssets="compile;contentfiles;build;analyzers" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) And !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.8" PrivateAssets="compile;contentfiles;build;analyzers" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.8" PrivateAssets="compile;contentfiles;build;analyzers" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.3" PrivateAssets="compile;contentfiles;build;analyzers" />
+  </ItemGroup>
+
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.8" PrivateAssets="compile;contentfiles;build;analyzers" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.8" PrivateAssets="compile;contentfiles;build;analyzers" />
     <PackageReference Include="System.Threading.Channels" Version="9.0.8" PrivateAssets="compile;contentfiles;build;analyzers" />
@@ -112,7 +123,7 @@
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
 
-  <ItemGroup Condition="!($(TargetFramework.StartsWith('net8')))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="Portable.System.DateTimeOnly" Version="9.0.1" PrivateAssets="compile;contentfiles;build;analyzers" />
   </ItemGroup>
 

--- a/Alpaca.Markets.Extensions/Statistics/EnumerableExtensions.cs
+++ b/Alpaca.Markets.Extensions/Statistics/EnumerableExtensions.cs
@@ -214,5 +214,28 @@ public static class EnumerableExtensions
     public static IEnumerable<IBar> GetSimpleMovingAverage(
         this IEnumerable<IBar> bars,
         Int32 window) =>
+#if NET10_0_OR_GREATER
+        toEnumerable(GetSimpleMovingAverageAsync(bars.EnsureNotNull().ToAsyncEnumerable(), window));
+#else
         GetSimpleMovingAverageAsync(bars.EnsureNotNull().ToAsyncEnumerable(), window).ToEnumerable();
+#endif
+
+#if NET10_0_OR_GREATER
+    // .NET 10's System.Linq.AsyncEnumerable intentionally omits sync-over-async ToEnumerable.
+    private static IEnumerable<T> toEnumerable<T>(IAsyncEnumerable<T> source)
+    {
+        var enumerator = source.GetAsyncEnumerator();
+        try
+        {
+            while (enumerator.MoveNextAsync().AsTask().GetAwaiter().GetResult())
+            {
+                yield return enumerator.Current;
+            }
+        }
+        finally
+        {
+            enumerator.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+    }
+#endif
 }

--- a/Alpaca.Markets.Extensions/Statistics/EnumerableExtensions.cs
+++ b/Alpaca.Markets.Extensions/Statistics/EnumerableExtensions.cs
@@ -215,27 +215,9 @@ public static class EnumerableExtensions
         this IEnumerable<IBar> bars,
         Int32 window) =>
 #if NET10_0_OR_GREATER
-        toEnumerable(GetSimpleMovingAverageAsync(bars.EnsureNotNull().ToAsyncEnumerable(), window));
+        GetSimpleMovingAverageAsync(bars.EnsureNotNull().ToAsyncEnumerable(), window)
+            .ToBlockingEnumerable();
 #else
         GetSimpleMovingAverageAsync(bars.EnsureNotNull().ToAsyncEnumerable(), window).ToEnumerable();
-#endif
-
-#if NET10_0_OR_GREATER
-    // .NET 10's System.Linq.AsyncEnumerable intentionally omits sync-over-async ToEnumerable.
-    private static IEnumerable<T> toEnumerable<T>(IAsyncEnumerable<T> source)
-    {
-        var enumerator = source.GetAsyncEnumerator();
-        try
-        {
-            while (enumerator.MoveNextAsync().AsTask().GetAwaiter().GetResult())
-            {
-                yield return enumerator.Current;
-            }
-        }
-        finally
-        {
-            enumerator.DisposeAsync().AsTask().GetAwaiter().GetResult();
-        }
-    }
 #endif
 }

--- a/Alpaca.Markets.Extensions/packages.lock.json
+++ b/Alpaca.Markets.Extensions/packages.lock.json
@@ -1027,9 +1027,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.11, )",
-        "resolved": "10.0.11",
-        "contentHash": "IBf7lbovvjGWVWXZX5cJ/cO0WXbId0Zq4BuSeT94mGZuOAP66oMeH9PTBZ9Jpp3Jb6jtK0qm/NyUbPRo1gC/wQ=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -1259,9 +1259,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.30, )",
-        "resolved": "8.0.30",
-        "contentHash": "SfmwuZjUPBTEoBMAsXZ/hWkaEK9oL+Y/UtAx7N6RyWHfcMt9J0ExrNPuOgTyPbCXIyiTBFsxFNrPLEZNPmJcvA=="
+        "requested": "[8.0.29, )",
+        "resolved": "8.0.29",
+        "contentHash": "HSBTfrkIZijz8z3ybLRKB7E8rHk4QQufFwpHa9fc5CMIgRhRzdn4mBGmlyXZqaueiMPtuJcnjresGvSTfaW8Mg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/Alpaca.Markets.Extensions/packages.lock.json
+++ b/Alpaca.Markets.Extensions/packages.lock.json
@@ -873,9 +873,7 @@
         "contentHash": "pYnAffJL7ARD/HCnnPvnFKSIHnTSmWz84WIlT9tPeQ4lHNiu0Az7N/8itihWvcF8sT+VVD5lq8V+ckMzu4SbOw==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8",
-          "System.Buffers": "4.5.1",
-          "System.Diagnostics.DiagnosticSource": "9.0.8",
-          "System.Memory": "4.5.5"
+          "System.Diagnostics.DiagnosticSource": "9.0.8"
         }
       },
       "Microsoft.Extensions.Options": {
@@ -893,7 +891,6 @@
         "resolved": "9.0.8",
         "contentHash": "tizSIOEsIgSNSSh+hKeUVPK7xmTIjR8s+mJWOu1KXV3htvNQiPMFRMO17OdI1y/4ZApdBVk49u/08QGC9yvLug==",
         "dependencies": {
-          "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
@@ -902,7 +899,6 @@
         "resolved": "17.11.4",
         "contentHash": "mudqUHhNpeqIdJoUx2YDWZO/I9uEDYVowan89R6wsomfnUJQk6HteoQTlNjZDixhT2B4IXMkMtgZtoceIjLRmA==",
         "dependencies": {
-          "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
@@ -931,8 +927,7 @@
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
           "Microsoft.Bcl.TimeProvider": "8.0.0",
-          "System.ComponentModel.Annotations": "4.5.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.ComponentModel.Annotations": "4.5.0"
         }
       },
       "Polly.Extensions.Http": {
@@ -943,17 +938,11 @@
           "Polly": "7.1.0"
         }
       },
-      "System.Buffers": {
-        "type": "Transitive",
-        "resolved": "4.5.1",
-        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
-      },
       "System.Collections.Immutable": {
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg==",
         "dependencies": {
-          "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
@@ -967,47 +956,18 @@
         "resolved": "9.0.8",
         "contentHash": "Lj8/a1Hzli1z6jo8H9urc16GxkpVJtJM+W9fmivXMNu7nwzHziGkxn4vO0DFscMbudkEVKSezdDuHk5kgM0X/g==",
         "dependencies": {
-          "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
         "resolved": "9.0.8",
-        "contentHash": "6vPmJt73mgUo1gzc/OcXlJvClz/2jxZ4TQPRfriVaLoGRH2mye530D9WHJYbFQRNMxF3PWCoeofsFdCyN7fLzA==",
-        "dependencies": {
-          "System.Buffers": "4.5.1",
-          "System.Memory": "4.5.5",
-          "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
-      "System.Memory": {
-        "type": "Transitive",
-        "resolved": "4.5.5",
-        "contentHash": "XIWiDvKPXaTveaB7HVganDlOCRoj03l+jrwNvcge/t8vhGYKvqV+dMv6G4SAX2NoNmN0wZfVPTAlFwZcZvVOUw==",
-        "dependencies": {
-          "System.Buffers": "4.5.1",
-          "System.Numerics.Vectors": "4.4.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
-        }
-      },
-      "System.Numerics.Vectors": {
-        "type": "Transitive",
-        "resolved": "4.4.0",
-        "contentHash": "UiLzLW+Lw6HLed1Hcg+8jSRttrbuXv7DANVj0DkL9g6EnnzbL75EB7EWsw5uRbhxd/4YdG8li5XizGWepmG3PQ=="
+        "contentHash": "6vPmJt73mgUo1gzc/OcXlJvClz/2jxZ4TQPRfriVaLoGRH2mye530D9WHJYbFQRNMxF3PWCoeofsFdCyN7fLzA=="
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
-      },
-      "System.Threading.Tasks.Extensions": {
-        "type": "Transitive",
-        "resolved": "4.5.4",
-        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
-        }
       },
       "alpaca.markets": {
         "type": "Project",
@@ -1018,6 +978,238 @@
           "Portable.System.DateTimeOnly": "[9.0.1, )",
           "System.IO.Pipelines": "[9.0.8, )",
           "System.Threading.Channels": "[9.0.8, )"
+        }
+      }
+    },
+    "net10.0": {
+      "IsExternalInit": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "jcdN7vpDwjnV7U9KGCv/oNIWHJ/RIbyrpVsLQL2qbj6Cbi5U3iafKsaMn1rP+qCbkLbkB0v6oAwbVEkqrUnlyg=="
+      },
+      "JetBrains.Annotations": {
+        "type": "Direct",
+        "requested": "[2025.2.2, )",
+        "resolved": "2025.2.2",
+        "contentHash": "0X56ZRizuHdrnPpgXjWV7f2tQO1FlQg5O1967OGKnI/4ZRNOK642J8L7brM1nYvrxTTU5TP1yRyXLRLaXLPQ8A=="
+      },
+      "Microsoft.CodeAnalysis.PublicApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[4.14.0, )",
+        "resolved": "4.14.0",
+        "contentHash": "5zBDSa8D1pfn5VyDzRekcYdVx/DGAzwegblVJhzdN0kvPt97TPr12haA6ZG0wS2WgBb1W42GeZJRiRtlNaoY1w=="
+      },
+      "Microsoft.Extensions.Http": {
+        "type": "Direct",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "ujx8RvcKzkxPFBguwgiygbwWVHVK0P7HFlNJ6I0JBRb28tzwe42jixBoA+dGmqG9IHepPVcm04vv2IDnU93ekA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Diagnostics": "10.0.11",
+          "Microsoft.Extensions.Logging": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Http.Polly": {
+        "type": "Direct",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "DIxaTXWdbjRJihAIutpDIgPbpD9PwW8lW0EIawlNH4zs7coCgwPnd9rYlzXYkuKKphnjcKYlo6gXFeg6z15GLg==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "10.0.11",
+          "Polly": "7.2.4",
+          "Polly.Extensions.Http": "3.0.0"
+        }
+      },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "IBf7lbovvjGWVWXZX5cJ/cO0WXbId0Zq4BuSeT94mGZuOAP66oMeH9PTBZ9Jpp3Jb6jtK0qm/NyUbPRo1gC/wQ=="
+      },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "G5q7OqtwIyGTkeIOAc3u2ZuV/kicQaec5EaRnc0pIeSnh9LUjj+PYQrJYBURvDt7twGl2PKA7nSN0kz1Zw5bnQ==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "8.0.0",
+          "Microsoft.SourceLink.Common": "8.0.0"
+        }
+      },
+      "MessagePack": {
+        "type": "Transitive",
+        "resolved": "3.1.7",
+        "contentHash": "gXpifaxbhfBqh8bVToQn9j+OgCnhXWMbRCV7RQIbCVa9CNJG1fY6oHAYYl+ER3Tb9uUIHiQ5QbGiGwwFhoagbA==",
+        "dependencies": {
+          "MessagePack.Annotations": "3.1.7",
+          "MessagePackAnalyzer": "3.1.7",
+          "Microsoft.NET.StringTools": "17.11.4"
+        }
+      },
+      "MessagePack.Annotations": {
+        "type": "Transitive",
+        "resolved": "3.1.7",
+        "contentHash": "IW1yX9viarFl/Dsio5G+pM90JkOSW4xhAiJcKxPPF5rzyp2/yCpieWju8G99QLEmaQeze2uQMEskUBA59YZmkw=="
+      },
+      "MessagePackAnalyzer": {
+        "type": "Transitive",
+        "resolved": "3.1.7",
+        "contentHash": "ZF+OOJTRS7Ogzb4gG36hPKVQk3kEbp6kkUcdRjhddDq/uSGcV4BKIdYiyJipExXyE/zsqYb0ic215O9kI+fjPA=="
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "wlhRqZW8LcJPa+vk2oLAc/REXDItHtkFQdf/QcXYGZbZOO13izcsKY1pCvuFQYwUiZD+hwSZwsKASjqT+BNaVg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "fVi053xdpda9Em7vSkmgVxO/PtgC2m78ekReKWsgcyskqY0U82Bz/MONwxpGzI0hElYKJfw+fupqMVeKW3fSaA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "rFn8RuszZn3qquPVkDytMUlPc2+rXl9MCoygwc1XmAgC5vg5/oXJ8hkOosOrLoBLsqdTy4lFwP6iQdPS9uSYOA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.11",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "PSmotV19c7E3lKed++uYo1kSiXFI+uTl37CBSrhq+CfLC3FCHjG7R91+xPnNehQfHS1b0Tzo/CCLPWH3qaEheg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "/a1aJz4m7ylhEDf25ugQChLQoN5XwoGjWw/BoR/ZWWKsO1v4DdJElS1uyngahz4B/eOzjFk1KNTkarRLE5wsIg=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "HT70uGPxMLqqnOzKMcnQtDmeV4r0KHr4qVCLhP7SXil9jMEm8sQXwcybxVVFGXZJ1V44xV0mLqQ54aZbcR2OiQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.11",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "se7Kx8QpJEt+nf26L4qIVAofGTDr1wbexxsh/Fm3Xc04xUkqUXK06KUS7FLwSQYSjqb7q9n+T7MEcXYBhI1Y5g==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "nUOJwgFkSiLHiVGFpU22pIJtuWYewuSYQ3JVuP/gdK8ASMT807Px+TYQiRWs6uSsOmoyFTaVCwKXTasczV6BpA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.11",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "Ljd0Uxoq5XpScD2Bg0nM/r3mwx7Ao5Uq24eo2ARxbGvqJ7Zht6rt2cJtwVRH4Cv+1ZVMdXz6TB43KbpmsxRrvQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "eY1GAKcTfD2maP27J84X9IovT3yjHJ2dVDzPmDg6/XqYvt3jMzJhtfQCLjG9pVsZGAd+8DQ2QrjaDcs2+VQLGw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "syEhXQ/sEaSBFaqzlp9gDGHX/nk6gkQkh1sIUpBO1mlBj3Phu1rmb4ML1uCiyPW9N6Kxfxv3y5FGObC+bV01Qw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.11",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.11",
+          "Microsoft.Extensions.Options": "10.0.11",
+          "Microsoft.Extensions.Primitives": "10.0.11"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.11",
+        "contentHash": "SXcz+kF+4Oo9b1+55zntpJFYfwb1jw66ioxptyNOOTDc8g2FHnBFWjZpsWfCvZIhzr0x+4e2trVTs4OKwQfBtw=="
+      },
+      "Microsoft.NET.StringTools": {
+        "type": "Transitive",
+        "resolved": "17.11.4",
+        "contentHash": "mudqUHhNpeqIdJoUx2YDWZO/I9uEDYVowan89R6wsomfnUJQk6HteoQTlNjZDixhT2B4IXMkMtgZtoceIjLRmA=="
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "dk9JPxTCIevS75HyEQ0E4OVAFhB2N+V9ShCXf8Q6FkUQZDkgLI12y679Nym1YqsiSysuQskT7Z+6nUf3yab6Vw=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "Polly": {
+        "type": "Transitive",
+        "resolved": "8.6.3",
+        "contentHash": "8X6mWAGDrgTHyqDthifiv9QGR+FgnRe13/sPhSR4ZbhXCqUDJuLrVqunB39LLbf87TXZ+06dMdopd6LpY4oK0w==",
+        "dependencies": {
+          "Polly.Core": "8.6.3"
+        }
+      },
+      "Polly.Core": {
+        "type": "Transitive",
+        "resolved": "8.6.3",
+        "contentHash": "xRlcE+1FidqIfZ7zxBT6klSblJ/7MAJq1x5yvYoLnwNhs8Xc2gp3Srf8wHG2NpFxVBqrldc3svhkMPJjSzTmzw=="
+      },
+      "Polly.Extensions.Http": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "drrG+hB3pYFY7w1c3BD+lSGYvH2oIclH8GRSehgfyP5kjnFnHKQuuBhuHLv+PWyFuaTDyk/vfRpnxOzd11+J8g==",
+        "dependencies": {
+          "Polly": "7.1.0"
+        }
+      },
+      "alpaca.markets": {
+        "type": "Project",
+        "dependencies": {
+          "MessagePack": "[3.1.7, )",
+          "Newtonsoft.Json": "[13.0.3, )",
+          "Polly": "[8.6.3, )"
         }
       }
     },
@@ -1067,9 +1259,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.29, )",
-        "resolved": "8.0.29",
-        "contentHash": "HSBTfrkIZijz8z3ybLRKB7E8rHk4QQufFwpHa9fc5CMIgRhRzdn4mBGmlyXZqaueiMPtuJcnjresGvSTfaW8Mg=="
+        "requested": "[8.0.30, )",
+        "resolved": "8.0.30",
+        "contentHash": "SfmwuZjUPBTEoBMAsXZ/hWkaEK9oL+Y/UtAx7N6RyWHfcMt9J0ExrNPuOgTyPbCXIyiTBFsxFNrPLEZNPmJcvA=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -1086,12 +1278,6 @@
         "requested": "[6.0.3, )",
         "resolved": "6.0.3",
         "contentHash": "hSHiq2m1ky7zUQgTp+/2h1K3lABIQ+GltRixoclHPg/Sc1vnfeS6g/Uy5moOVZKrZJdQiFPFZd6OobBp3tZcFg=="
-      },
-      "System.Threading.Channels": {
-        "type": "Direct",
-        "requested": "[9.0.8, )",
-        "resolved": "9.0.8",
-        "contentHash": "kpvkzWJoHR9os3/4LL5feaTTLD92+XzTqPyYLU2tw2BoJ4MrWCfkjGXtL7MsdpV/20e1+SamCbrPj2L9ptwgBA=="
       },
       "MessagePack": {
         "type": "Transitive",
@@ -1266,6 +1452,11 @@
         "type": "Transitive",
         "resolved": "9.0.8",
         "contentHash": "6vPmJt73mgUo1gzc/OcXlJvClz/2jxZ4TQPRfriVaLoGRH2mye530D9WHJYbFQRNMxF3PWCoeofsFdCyN7fLzA=="
+      },
+      "System.Threading.Channels": {
+        "type": "Transitive",
+        "resolved": "9.0.8",
+        "contentHash": "kpvkzWJoHR9os3/4LL5feaTTLD92+XzTqPyYLU2tw2BoJ4MrWCfkjGXtL7MsdpV/20e1+SamCbrPj2L9ptwgBA=="
       },
       "alpaca.markets": {
         "type": "Project",

--- a/Alpaca.Markets.Tests/Alpaca.Markets.Tests.csproj
+++ b/Alpaca.Markets.Tests/Alpaca.Markets.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>..\Alpaca.Markets.snk</AssemblyOriginatorKeyFile>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -13,8 +13,17 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.11" />
+  </ItemGroup>
+
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.8" />
+    <PackageReference Include="System.Threading.Channels" Version="9.0.8" />
+    <PackageReference Include="System.IO.Pipelines" Version="9.0.8" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.1.0" />

--- a/Alpaca.Markets/Alpaca.Markets.csproj
+++ b/Alpaca.Markets/Alpaca.Markets.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net462;net8.0;net10.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>..\Alpaca.Markets.snk</AssemblyOriginatorKeyFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -66,7 +66,7 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 
-  <PropertyGroup Condition="($(TargetFramework.StartsWith('net8')))">
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
@@ -121,10 +121,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Threading.Channels" Version="9.0.8" PrivateAssets="compile;contentfiles;build;analyzers" />
-    <PackageReference Include="System.IO.Pipelines" Version="9.0.8" PrivateAssets="compile;contentfiles;build;analyzers" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" PrivateAssets="compile;contentfiles;build;analyzers" />
     <PackageReference Include="Polly" Version="8.6.3" PrivateAssets="compile;contentfiles;build;analyzers" />
+  </ItemGroup>
+
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
+    <PackageReference Include="System.Threading.Channels" Version="9.0.8" PrivateAssets="compile;contentfiles;build;analyzers" />
+    <PackageReference Include="System.IO.Pipelines" Version="9.0.8" PrivateAssets="compile;contentfiles;build;analyzers" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
@@ -133,7 +136,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
-  <ItemGroup Condition="!$(TargetFramework.StartsWith('net8'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="Portable.System.DateTimeOnly" Version="9.0.1" PrivateAssets="compile;contentfiles;build;analyzers" />
   </ItemGroup>
 

--- a/Alpaca.Markets/DataStreamingClientBase.cs
+++ b/Alpaca.Markets/DataStreamingClientBase.cs
@@ -207,7 +207,11 @@ internal abstract class DataStreamingClientBase<TConfiguration> :
                     break;
 
                 default:
+#if NET8_0_OR_GREATER
+                    onWarning.Invoke($"Ignored MessagePack data type {Enum.GetName(type)}");
+#else
                     onWarning.Invoke($"Ignored MessagePack data type {Enum.GetName(typeof(MessagePackType), type)}");
+#endif
                     break;
             }
 

--- a/Alpaca.Markets/Helpers/EnumExtensions.cs
+++ b/Alpaca.Markets/Helpers/EnumExtensions.cs
@@ -11,12 +11,22 @@ internal static class EnumExtensions
         T> where T : struct, Enum
     {
         public static readonly IReadOnlyDictionary<String, T> ValuesByNames =
+#if NET8_0_OR_GREATER
+            Enum.GetValues<T>()
+#else
             Enum.GetValues(typeof(T)).OfType<T>()
+#endif
                 .ToDictionary(getJsonName, value => value);
 
         private static string getJsonName(
             T value) =>
-            typeof(T).GetField(Enum.GetName(typeof(T), value) ?? value.ToString())?
+            typeof(T).GetField(
+#if NET8_0_OR_GREATER
+                    Enum.GetName(value)
+#else
+                    Enum.GetName(typeof(T), value)
+#endif
+                    ?? value.ToString())?
                 .GetCustomAttribute<EnumMemberAttribute>()?.Value ?? value.ToString();
     }
 

--- a/Alpaca.Markets/packages.lock.json
+++ b/Alpaca.Markets/packages.lock.json
@@ -647,9 +647,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.11, )",
-        "resolved": "10.0.11",
-        "contentHash": "IBf7lbovvjGWVWXZX5cJ/cO0WXbId0Zq4BuSeT94mGZuOAP66oMeH9PTBZ9Jpp3Jb6jtK0qm/NyUbPRo1gC/wQ=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -739,9 +739,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.30, )",
-        "resolved": "8.0.30",
-        "contentHash": "SfmwuZjUPBTEoBMAsXZ/hWkaEK9oL+Y/UtAx7N6RyWHfcMt9J0ExrNPuOgTyPbCXIyiTBFsxFNrPLEZNPmJcvA=="
+        "requested": "[8.0.29, )",
+        "resolved": "8.0.29",
+        "contentHash": "HSBTfrkIZijz8z3ybLRKB7E8rHk4QQufFwpHa9fc5CMIgRhRzdn4mBGmlyXZqaueiMPtuJcnjresGvSTfaW8Mg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/Alpaca.Markets/packages.lock.json
+++ b/Alpaca.Markets/packages.lock.json
@@ -537,12 +537,7 @@
         "type": "Direct",
         "requested": "[9.0.8, )",
         "resolved": "9.0.8",
-        "contentHash": "6vPmJt73mgUo1gzc/OcXlJvClz/2jxZ4TQPRfriVaLoGRH2mye530D9WHJYbFQRNMxF3PWCoeofsFdCyN7fLzA==",
-        "dependencies": {
-          "System.Buffers": "4.5.1",
-          "System.Memory": "4.5.5",
-          "System.Threading.Tasks.Extensions": "4.5.4"
-        }
+        "contentHash": "6vPmJt73mgUo1gzc/OcXlJvClz/2jxZ4TQPRfriVaLoGRH2mye530D9WHJYbFQRNMxF3PWCoeofsFdCyN7fLzA=="
       },
       "System.Threading.Channels": {
         "type": "Direct",
@@ -583,7 +578,6 @@
         "resolved": "17.11.4",
         "contentHash": "mudqUHhNpeqIdJoUx2YDWZO/I9uEDYVowan89R6wsomfnUJQk6HteoQTlNjZDixhT2B4IXMkMtgZtoceIjLRmA==",
         "dependencies": {
-          "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
@@ -599,21 +593,14 @@
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
           "Microsoft.Bcl.TimeProvider": "8.0.0",
-          "System.ComponentModel.Annotations": "4.5.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.ComponentModel.Annotations": "4.5.0"
         }
-      },
-      "System.Buffers": {
-        "type": "Transitive",
-        "resolved": "4.5.1",
-        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
       },
       "System.Collections.Immutable": {
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg==",
         "dependencies": {
-          "System.Memory": "4.5.5",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
@@ -622,33 +609,102 @@
         "resolved": "4.5.0",
         "contentHash": "UxYQ3FGUOtzJ7LfSdnYSFd7+oEv6M8NgUatatIN2HxNtDdlcvFAf+VIq4Of9cDMJEJC0aSRv/x898RYhB4Yppg=="
       },
-      "System.Memory": {
-        "type": "Transitive",
-        "resolved": "4.5.5",
-        "contentHash": "XIWiDvKPXaTveaB7HVganDlOCRoj03l+jrwNvcge/t8vhGYKvqV+dMv6G4SAX2NoNmN0wZfVPTAlFwZcZvVOUw==",
-        "dependencies": {
-          "System.Buffers": "4.5.1",
-          "System.Numerics.Vectors": "4.4.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
-        }
-      },
-      "System.Numerics.Vectors": {
-        "type": "Transitive",
-        "resolved": "4.4.0",
-        "contentHash": "UiLzLW+Lw6HLed1Hcg+8jSRttrbuXv7DANVj0DkL9g6EnnzbL75EB7EWsw5uRbhxd/4YdG8li5XizGWepmG3PQ=="
-      },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      }
+    },
+    "net10.0": {
+      "IsExternalInit": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "jcdN7vpDwjnV7U9KGCv/oNIWHJ/RIbyrpVsLQL2qbj6Cbi5U3iafKsaMn1rP+qCbkLbkB0v6oAwbVEkqrUnlyg=="
       },
-      "System.Threading.Tasks.Extensions": {
-        "type": "Transitive",
-        "resolved": "4.5.4",
-        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
+      "JetBrains.Annotations": {
+        "type": "Direct",
+        "requested": "[2025.2.2, )",
+        "resolved": "2025.2.2",
+        "contentHash": "0X56ZRizuHdrnPpgXjWV7f2tQO1FlQg5O1967OGKnI/4ZRNOK642J8L7brM1nYvrxTTU5TP1yRyXLRLaXLPQ8A=="
+      },
+      "MessagePack": {
+        "type": "Direct",
+        "requested": "[3.1.7, )",
+        "resolved": "3.1.7",
+        "contentHash": "gXpifaxbhfBqh8bVToQn9j+OgCnhXWMbRCV7RQIbCVa9CNJG1fY6oHAYYl+ER3Tb9uUIHiQ5QbGiGwwFhoagbA==",
         "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+          "MessagePack.Annotations": "3.1.7",
+          "MessagePackAnalyzer": "3.1.7",
+          "Microsoft.NET.StringTools": "17.11.4"
         }
+      },
+      "Microsoft.CodeAnalysis.PublicApiAnalyzers": {
+        "type": "Direct",
+        "requested": "[4.14.0, )",
+        "resolved": "4.14.0",
+        "contentHash": "5zBDSa8D1pfn5VyDzRekcYdVx/DGAzwegblVJhzdN0kvPt97TPr12haA6ZG0wS2WgBb1W42GeZJRiRtlNaoY1w=="
+      },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.11, )",
+        "resolved": "10.0.11",
+        "contentHash": "IBf7lbovvjGWVWXZX5cJ/cO0WXbId0Zq4BuSeT94mGZuOAP66oMeH9PTBZ9Jpp3Jb6jtK0qm/NyUbPRo1gC/wQ=="
+      },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "G5q7OqtwIyGTkeIOAc3u2ZuV/kicQaec5EaRnc0pIeSnh9LUjj+PYQrJYBURvDt7twGl2PKA7nSN0kz1Zw5bnQ==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "8.0.0",
+          "Microsoft.SourceLink.Common": "8.0.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.3, )",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "Polly": {
+        "type": "Direct",
+        "requested": "[8.6.3, )",
+        "resolved": "8.6.3",
+        "contentHash": "8X6mWAGDrgTHyqDthifiv9QGR+FgnRe13/sPhSR4ZbhXCqUDJuLrVqunB39LLbf87TXZ+06dMdopd6LpY4oK0w==",
+        "dependencies": {
+          "Polly.Core": "8.6.3"
+        }
+      },
+      "MessagePack.Annotations": {
+        "type": "Transitive",
+        "resolved": "3.1.7",
+        "contentHash": "IW1yX9viarFl/Dsio5G+pM90JkOSW4xhAiJcKxPPF5rzyp2/yCpieWju8G99QLEmaQeze2uQMEskUBA59YZmkw=="
+      },
+      "MessagePackAnalyzer": {
+        "type": "Transitive",
+        "resolved": "3.1.7",
+        "contentHash": "ZF+OOJTRS7Ogzb4gG36hPKVQk3kEbp6kkUcdRjhddDq/uSGcV4BKIdYiyJipExXyE/zsqYb0ic215O9kI+fjPA=="
+      },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
+      },
+      "Microsoft.NET.StringTools": {
+        "type": "Transitive",
+        "resolved": "17.11.4",
+        "contentHash": "mudqUHhNpeqIdJoUx2YDWZO/I9uEDYVowan89R6wsomfnUJQk6HteoQTlNjZDixhT2B4IXMkMtgZtoceIjLRmA=="
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "dk9JPxTCIevS75HyEQ0E4OVAFhB2N+V9ShCXf8Q6FkUQZDkgLI12y679Nym1YqsiSysuQskT7Z+6nUf3yab6Vw=="
+      },
+      "Polly.Core": {
+        "type": "Transitive",
+        "resolved": "8.6.3",
+        "contentHash": "xRlcE+1FidqIfZ7zxBT6klSblJ/7MAJq1x5yvYoLnwNhs8Xc2gp3Srf8wHG2NpFxVBqrldc3svhkMPJjSzTmzw=="
       }
     },
     "net8.0": {
@@ -683,9 +739,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.29, )",
-        "resolved": "8.0.29",
-        "contentHash": "HSBTfrkIZijz8z3ybLRKB7E8rHk4QQufFwpHa9fc5CMIgRhRzdn4mBGmlyXZqaueiMPtuJcnjresGvSTfaW8Mg=="
+        "requested": "[8.0.30, )",
+        "resolved": "8.0.30",
+        "contentHash": "SfmwuZjUPBTEoBMAsXZ/hWkaEK9oL+Y/UtAx7N6RyWHfcMt9J0ExrNPuOgTyPbCXIyiTBFsxFNrPLEZNPmJcvA=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ This SDK has also GitHub WiKi which contains some useful information: https://gi
 
 ## Framework Support
 
-- Keep in mind .NET targets list: .NET Standard 2.0, .NET Standard 2.1, .NET Framework 4.6.2, .NET 8.0
+- Keep in mind .NET targets list: .NET Standard 2.0, .NET Standard 2.1, .NET Framework 4.6.2, .NET 8.0, .NET 10.0
 - Use common denominator types as much as possible and conditional compilation as a last resort
 - Uses latest available C# features provided by the latest .NET SDK compatible with targets
 

--- a/README.md
+++ b/README.md
@@ -60,9 +60,11 @@ Use the `Environments.Paper.GetAlpacaDataStreamingClient(...)` factory method to
 
 ### Build instructions
 
-1.  Install your OS's latest version of the [.NET 9.0 SDK](https://dotnet.microsoft.com/download).
+1.  Install your OS's latest version of the [.NET 10.0 SDK](https://dotnet.microsoft.com/download).
 2.  Clone the local version of this repository or your fork (if you want to make changes).
 3.  Build the packages using the `dotnet build` command running in the root directory of the cloned repo.
+
+The NuGet packages multi-target .NET Standard 2.0/2.1, .NET Framework 4.6.2, .NET 8.0, and .NET 10.0 — consumers do not need the .NET 10 SDK unless they are building this repository.
 
 ### Preview the documentation locally
 

--- a/UsageExamples/UsageExamples.csproj
+++ b/UsageExamples/UsageExamples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net4.8;net8.0</TargetFrameworks>
+    <TargetFrameworks>net4.8;net10.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <TrimmerDefaultAction>link</TrimmerDefaultAction>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -21,9 +21,6 @@
     </PackageReference>
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
     <PackageReference Include="OoplesFinance.StockIndicators" Version="1.0.53" />
-    <PackageReference Include="Portable.System.DateTimeOnly" Version="9.0.1" />
-    <PackageReference Include="System.Threading.Channels" Version="9.0.8" />
-    <PackageReference Include="System.IO.Pipelines" Version="9.0.8" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Polly" Version="8.6.3" />
   </ItemGroup>
@@ -31,6 +28,9 @@
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
     <PackageReference Include="System.Net.Http.WinHttpHandler" Version="9.0.8" />
+    <PackageReference Include="Portable.System.DateTimeOnly" Version="9.0.1" />
+    <PackageReference Include="System.Threading.Channels" Version="9.0.8" />
+    <PackageReference Include="System.IO.Pipelines" Version="9.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docs/superpowers/plans/2026-08-12-net10-multi-target.md
+++ b/docs/superpowers/plans/2026-08-12-net10-multi-target.md
@@ -1,0 +1,58 @@
+# Add net10.0 Multi-Targeting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add first-class `net10.0` library assets while keeping `net8.0` and down-level TFMs.
+
+**Architecture:** Extend `TargetFrameworks` with `net10.0`, align shipping System/Extensions packages to 10.0.x, broaden modern-TFM MSBuild conditions, move tests/examples to net10.0, refresh locks + PackageValidation, update CI runtimes and docs.
+
+**Tech Stack:** .NET SDK 10.0.302, multi-targeted class libraries, xUnit tests, GitHub Actions `setup-dotnet`.
+
+**Spec:** `docs/superpowers/specs/2026-08-12-net10-multi-target-design.md`
+
+## Global Constraints
+
+- Keep TFMs: `netstandard2.0;netstandard2.1;net462;net8.0;net10.0` (do not drop net8)
+- Shipping deps → 10.0.x line (prefer 10.0.11 to match tests)
+- Additive change only (no major version bump for dropping TFMs)
+- Treat warnings as errors; restore locked mode for library packages
+
+---
+
+### Task 1: Library TFMs, conditions, PackageReferences
+
+**Files:**
+- `Alpaca.Markets/Alpaca.Markets.csproj`
+- `Alpaca.Markets.Extensions/Alpaca.Markets.Extensions.csproj`
+
+- [x] Add `net10.0` to `TargetFrameworks`
+- [x] Broaden trim + DateTimeOnly conditions to net8 **and** net10
+- [x] Bump System.*/Microsoft.Extensions.* to 10.0.11 (WinHttpHandler 10.0.11; Portable.System.DateTimeOnly latest compatible)
+- [x] Regenerate lock files with unlocked restore then re-enable locked mode
+
+### Task 2: Tests and UsageExamples → net10.0
+
+**Files:**
+- `Alpaca.Markets.Tests/Alpaca.Markets.Tests.csproj`
+- `Alpaca.Markets.Extensions.Tests/Alpaca.Markets.Extensions.Tests.csproj`
+- `UsageExamples/UsageExamples.csproj`
+
+- [x] Tests: `TargetFramework` → `net10.0`
+- [x] Examples: `net4.8;net10.0`; bump System.* to 10.0.11
+
+### Task 3: CI + docs
+
+**Files:**
+- `.github/workflows/release.yml` (+ other workflows that build/test if needed)
+- `README.md`, `CLAUDE.md`
+- Spec status → approved/implemented
+
+- [x] Install 8.0.x and 10.0.x runtimes alongside global.json SDK
+- [x] Document .NET 10 in supported targets
+
+### Task 4: Validate
+
+- [x] `dotnet build` (0 errors/warnings)
+- [x] `dotnet test` passes
+- [x] PackageValidation / generate suppressions if needed
+- [x] Confirm nupkg contains `lib/net10.0/` and still `lib/net8.0/`

--- a/docs/superpowers/specs/2026-08-12-net10-multi-target-design.md
+++ b/docs/superpowers/specs/2026-08-12-net10-multi-target-design.md
@@ -1,0 +1,110 @@
+# Design: Add .NET 10 multi-targeting (Path A)
+
+**Date:** 2026-08-12  
+**Status:** Superseded by `2026-08-13-net10-only-design.md`  
+**Branch:** `feature/net10-multi-target`
+
+## Goal
+
+Ship first-class `net10.0` assets in `Alpaca.Markets` and `Alpaca.Markets.Extensions` while keeping existing TFMs (including `net8.0`) for backward compatibility. Dropping `net8.0` is explicitly deferred to a later PR.
+
+## Non-goals
+
+- Removing `net8.0`, `netstandard2.0`, `netstandard2.1`, or `net462`
+- Requiring consumers to install .NET 10 to use the package on net8 / netstandard / net462
+- Changing public API surface beyond what PackageValidation/PublicAPI already allow
+
+## Current state
+
+| Layer | Today |
+|-------|--------|
+| Build SDK | `global.json` → `10.0.302` |
+| Library TFMs | `netstandard2.0;netstandard2.1;net462;net8.0` |
+| Library deps | `System.*` / `Microsoft.Extensions.*` **9.0.8** |
+| Tests | `net8.0` (some test-only packages already 10.0.x) |
+| CI | Installs SDK from `global.json` only |
+
+## Target state
+
+| Layer | After this work |
+|-------|-----------------|
+| Library TFMs | `netstandard2.0;netstandard2.1;net462;net8.0;net10.0` |
+| Nupkg | Adds `lib/net10.0/*.dll` (+ XML docs) |
+| Library deps | Shipping `System.*` / `Microsoft.Extensions.*` → **10.0.x** (aligned with test packages, e.g. 10.0.11) |
+| Tests / UsageExamples | Primary modern TFM → `net10.0` (examples keep `net4.8;net10.0`) |
+| CI | Explicitly install runtimes needed to build/test multi-TFM (at least 8.0 + 10.0) |
+| Docs | README/CLAUDE: supported targets include .NET 10; build still requires SDK 10 |
+
+## Design decisions
+
+### 1. Multi-target, do not replace
+
+Adding `net10.0` is an additive NuGet change. Net8 consumers continue to resolve `lib/net8.0/`. Net10 consumers get `lib/net10.0/`.
+
+### 2. Broaden “modern .NET” MSBuild conditions
+
+Replace narrow `StartsWith('net8')` checks used for trim and for *excluding* `Portable.System.DateTimeOnly` so they apply to `net8.0` **and** `net10.0` (e.g. `net8.0` / `net10.0` via `StartsWith('net8') Or StartsWith('net10')`, or equivalent). Down-level TFMs keep portable shims.
+
+### 3. Dependency line → 10.0.x for libraries
+
+Bump:
+
+- `System.Threading.Channels`
+- `System.IO.Pipelines`
+- `System.Net.Http.WinHttpHandler` (net4 only)
+- `Microsoft.Extensions.Http` / `Microsoft.Extensions.Http.Polly` (Extensions)
+- `Portable.System.DateTimeOnly` if a 10.x line exists; otherwise keep current major that still supports down-level TFMs
+
+These packages multi-target; net8 consumers can still restore them. Lock files must be regenerated (`RestoreLockedMode`).
+
+### 4. Tests and examples on net10
+
+- `Alpaca.Markets.Tests` / `Alpaca.Markets.Extensions.Tests` → `net10.0`
+- `UsageExamples` → `net4.8;net10.0`
+- Keeps CI exercising the new asset; net8 library asset remains covered by PackageValidation / multi-TFM build
+
+### 5. PackageValidation + PublicAPI
+
+- Build with PackageValidation enabled; regenerate `CompatibilitySuppressions.xml` via the project’s documented generate-suppression property if new cross-TFM `CP*` diffs appear for `lib/net10.0`
+- Confirm PublicAPI shipped/unshipped still pass per TFM
+
+### 6. Versioning
+
+Additive TFM support → **minor** (or stay on current beta line). No major bump. Dropping net8 later is the breaking/major candidate.
+
+### 7. CI
+
+Update `release.yml` (and other workflows that build/test) so `setup-dotnet` installs:
+
+- SDK from `global.json` (10.0.302)
+- Explicit `8.0.x` and `10.0.x` runtimes (or equivalent multi-version install)
+
+Ensures tests and multi-target builds do not silently rely on roll-forward alone.
+
+## Implementation outline
+
+1. Update both library `.csproj` TFMs + conditions + PackageReferences
+2. Update test/example projects to `net10.0`
+3. Regenerate `packages.lock.json` for both libraries
+4. Build Release; fix PackageValidation suppressions / PublicAPI as needed
+5. Update CI workflow runtime installs
+6. Update README + CLAUDE.md target lists
+7. `dotnet build` + `dotnet test` on SDK 10; verify nupkg contains `lib/net10.0/`
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| PackageValidation noise for new TFM | Generate suppressions only for intentional diffs; review file |
+| Dependabot already on 10.x for tests, 9.x for libs | Align libraries to 10.x in this PR intentionally |
+| Local machines missing net8 runtime | CI installs both; document SDK 10 for contributors |
+| Condition typos excluding DateTimeOnly on net10 | Explicit net8 \|\| net10 conditions; verify net10 build uses BCL `DateTimeOnly` |
+
+## Success criteria
+
+- [ ] Both packages include `lib/net10.0/`
+- [ ] Both packages still include `lib/net8.0/` (and existing down-level TFMs)
+- [ ] Solution builds with 0 warnings/errors under SDK 10.0.302
+- [ ] Unit tests pass on `net10.0`
+- [ ] Docs list .NET 10 as a supported target; build instructions remain SDK 10
+- [ ] CI installs runtimes required for multi-TFM verification

--- a/docs/superpowers/specs/2026-08-13-net10-only-design.md
+++ b/docs/superpowers/specs/2026-08-13-net10-only-design.md
@@ -1,0 +1,88 @@
+# Design: .NET 10–only targeting
+
+**Date:** 2026-08-13  
+**Status:** Approved  
+**Branch:** `feature/net10-multi-target` (reworked)
+
+## Goal
+
+Rework the current net10 multi-target work into a single-TFM .NET 10 SDK. Drop `net8.0`, `netstandard2.0`, `netstandard2.1`, and `net462`. Remove framework `#if` dual paths and down-level shims. Keep package versioning on the **8.0.0-beta** line.
+
+Supersedes the “keep net8” parts of `docs/superpowers/specs/2026-08-12-net10-multi-target-design.md`.
+
+## Non-goals
+
+- Preserving NuGet assets for net8 / netstandard / net462
+- A major version bump for this support drop
+- Broker API work
+- Public API shape changes unrelated to TFM cleanup
+
+## Target state
+
+| Layer | After |
+|-------|--------|
+| Library TFMs | `net10.0` only (`Alpaca.Markets`, `Alpaca.Markets.Extensions`) |
+| Tests | `net10.0` |
+| UsageExamples | `net10.0` only (drop `net4.8`) |
+| Package versions | Stay on `8.0.0-beta*` |
+| Shipping deps | `System.*` / `Microsoft.Extensions.*` **10.0.x** on the single TFM |
+| CI | SDK from `global.json` + .NET 10 runtime only (no 8.0.x install) |
+| Docs | Supported target: .NET 10 |
+
+## Design decisions
+
+### 1. Single TFM
+
+Both libraries use `<TargetFramework>net10.0</TargetFramework>` (not multi-target). NuGet ships only `lib/net10.0/`. Consumers must use .NET 10 (or a compatible higher TFM when one exists).
+
+### 2. Delete framework conditionals
+
+In library and Extensions code, remove `#if NETFRAMEWORK` / `NETSTANDARD*` / `NET6_0_OR_GREATER` / `NET8_0_OR_GREATER` / `NET10_0_OR_GREATER` dual implementations. Keep the modern (.NET 10) branch only.
+
+Examples (non-exhaustive):
+
+- `CancelAsync()` instead of `Cancel()`
+- Generic `Enum.GetValues<T>()` / `Enum.GetName(value)`
+- Net-modern HTTP / WebSocket / trim attribute paths without `#else`
+
+### 3. Portable.Helpers
+
+Remove polyfills that exist only for down-level TFMs (`Index`, `Range`, KeyValuePair extensions, `CallerArgumentExpressionAttribute` polyfill). Keep only helpers that remain useful on net10 without `#if` (e.g. `EnsureNotNull` / `ValidatedNotNullAttribute`), or move those into the main projects and delete the shared project if nothing shared remains.
+
+### 4. Package reference simplification
+
+Drop down-level-only packages and TFM-conditioned ItemGroups:
+
+- `Portable.System.DateTimeOnly`
+- `System.Net.Http.WinHttpHandler` (net4)
+- `Microsoft.NETFramework.ReferenceAssemblies`
+- `IsExternalInit` if no longer required on net10
+- Extensions “net8-only” and “not net8” package splits — one set of 10.0.x references
+
+Regenerate `packages.lock.json` under locked restore.
+
+### 5. Versioning & compatibility tooling
+
+- Keep `Version` / `AssemblyVersion` / `FileVersion` on the 8.0.0-beta line
+- Release notes: first-class support is .NET 10 only; older TFMs removed
+- PackageValidation / `CompatibilitySuppressions.xml` / PublicAPI: update for single `net10.0` asset (generate suppressions only for intentional diffs)
+
+### 6. Tests, examples, CI, docs
+
+- Test projects: `net10.0` only
+- UsageExamples: `net10.0` only; remove net4-specific PackageReferences and conditions
+- `release.yml`: remove explicit `8.0.x` runtime install
+- README + CLAUDE.md: list .NET 10 as the supported target; build still requires SDK 10 from `global.json`
+
+## Consumer impact
+
+Apps targeting net8 / netstandard / net462 cannot consume the new package assets without retargeting to `net10.0`. This is intentional.
+
+## Success criteria
+
+- [ ] Both packages ship only `lib/net10.0/`
+- [ ] No remaining `#if` framework dual paths in library/Extensions production code (except any truly unavoidable analyzer-only cases reviewed case-by-case)
+- [ ] Solution builds with 0 warnings/errors under SDK 10.0.302
+- [ ] `dotnet test` passes on net10.0
+- [ ] Docs and CI match net10-only support
+- [ ] Package versions remain on 8.0.0-beta line


### PR DESCRIPTION
## Summary
- Add `net10.0` to `Alpaca.Markets` and `Alpaca.Markets.Extensions` alongside existing TFMs (`netstandard2.0/2.1`, `net462`, `net8.0`)
- Use TFM-conditional package versions: `Microsoft.Extensions.*` 10.0.11 on net10 only; net8/down-level stay on 9.0.8; omit framework packages on net10 where the BCL provides them
- Multi-target unit tests to `net8.0;net10.0`, update CI to install 8.0 + 10.0 runtimes, and document supported targets in README/CLAUDE

## Test plan
- [x] `dotnet build` — 0 warnings / 0 errors
- [x] `dotnet test --framework net8.0` — 309 passed, 2 skipped
- [x] `dotnet test --framework net10.0` — 309 passed, 2 skipped
- [x] Confirm nupkgs include both `lib/net8.0/` and `lib/net10.0/`
- [x] CI green on the PR (SDK 10 + runtimes 8/10)


Made with [Cursor](https://cursor.com)